### PR TITLE
Upgrade to node 45

### DIFF
--- a/examples/gm/index.ts
+++ b/examples/gm/index.ts
@@ -1,5 +1,5 @@
 import { Client, type XmtpEnv } from "@xmtp/node-sdk";
-import { createSigner, getEncryptionKeyFromHex } from "@/helpers";
+import { createSigner, createUser, getEncryptionKeyFromHex } from "@/helpers";
 
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db

--- a/examples/gm/index.ts
+++ b/examples/gm/index.ts
@@ -1,5 +1,5 @@
 import { Client, type XmtpEnv } from "@xmtp/node-sdk";
-import { createSigner, createUser, getEncryptionKeyFromHex } from "@/helpers";
+import { createSigner, getEncryptionKeyFromHex } from "@/helpers";
 
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -13,7 +13,6 @@ export const createSigner = (privateKey: `0x${string}`) => {
   const account = privateKeyToAccount(privateKey);
   /* Return the signer */
   return {
-    walletType: "EOA",
     getAddress: () => account.address,
     signMessage: async (message: string) => {
       const signature = await account.signMessage({

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -13,6 +13,7 @@ export const createSigner = (privateKey: `0x${string}`) => {
   const account = privateKeyToAccount(privateKey);
   /* Return the signer */
   return {
+    walletType: "EOA",
     getAddress: () => account.address,
     signMessage: async (message: string) => {
       const signature = await account.signMessage({

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "integrations/*"
   ],
   "scripts": {
+    "build": "tsc",
     "clean": "rimraf node_modules && yarn clean:dbs",
     "clean:dbs": "rimraf *.db3* ||:",
     "examples:gated": "tsx --env-file=.env examples/gated-group/index.ts",
@@ -20,7 +21,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "0.0.42",
+    "@xmtp/node-sdk": "0.0.45",
     "alchemy-sdk": "^3.0.0",
     "openai": "latest",
     "tsx": "^4.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/node-bindings@npm:^0.0.38":
+  version: 0.0.38
+  resolution: "@xmtp/node-bindings@npm:0.0.38"
+  checksum: 10/a9452a913cdda5cd050b91ed34358b8975524d1c5e6434db51b1d60f13a29069b531ee566811ab4ed339713ad0e041e83f24fc916684c968c322ba63f21319f3
+  languageName: node
+  linkType: hard
+
 "@xmtp/node-sdk@npm:0.0.42":
   version: 0.0.42
   resolution: "@xmtp/node-sdk@npm:0.0.42"
@@ -1291,6 +1298,19 @@ __metadata:
     "@xmtp/node-bindings": "npm:^0.0.37"
     "@xmtp/proto": "npm:^3.72.3"
   checksum: 10/6163ede6d9cd7bc36b3a237d9a63a8be0041a11a1eefc6f56fefbf7cb8b8cc02c817c4696996a29a4f296d7545fd3172d8ebf8f85e1aeb23dcff917719dfcd10
+  languageName: node
+  linkType: hard
+
+"@xmtp/node-sdk@npm:0.0.45":
+  version: 0.0.45
+  resolution: "@xmtp/node-sdk@npm:0.0.45"
+  dependencies:
+    "@xmtp/content-type-group-updated": "npm:^2.0.0"
+    "@xmtp/content-type-primitives": "npm:^2.0.0"
+    "@xmtp/content-type-text": "npm:^2.0.0"
+    "@xmtp/node-bindings": "npm:^0.0.38"
+    "@xmtp/proto": "npm:^3.72.3"
+  checksum: 10/70eb659105a585e651f9c9a538b98014476212a1023308b88012317a5c64e58b4a2d920891c131e763d449823cb8d1e126a4041ff73a803b5593702f43c08e8c
   languageName: node
   linkType: hard
 
@@ -3831,7 +3851,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:0.0.42"
+    "@xmtp/node-sdk": "npm:0.0.45"
     alchemy-sdk: "npm:^3.0.0"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"


### PR DESCRIPTION
Hey @rygine seems there is a breaking change for the helpers, flagging this one 

```
examples/gm/index.ts:27:38 - error TS2345: Argument of type '{ getAddress: () => `0x${string}`; signMessage: (message: string) => Promise<ByteArray>; }' is not assignable to parameter of type 'Signer'.
  Type '{ getAddress: () => `0x${string}`; signMessage: (message: string) => Promise<ByteArray>; }' is missing the following properties from type '{ walletType: "SCW"; getAddress: GetAddress; signMessage: SignMessage; getBlockNumber?: GetBlockNumber | undefined; getChainId: GetChainId; }': walletType, getChainId

27   const client = await Client.create(signer, encryptionKey, { env });
                                        ~~~~~~
```