### PR TITLE
Update XMTP_ENV value to 'dev' in all .env files

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -873,7 +873,7 @@ Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the officia
 
 ### Work in local network
 
-`Dev` and `production` networks are hosted by XMTP, while `local` network is hosted by yourself, so it's faster for development purposes.
+`dev` and `production` networks are hosted by XMTP, while `local` network is hosted by yourself.
 
 - 1. Install docker
 - 2. Start the XMTP service and database

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -179,7 +179,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 ```bash
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # encryption key for the local database
-XMTP_ENV= # local, dev, production
+XMTP_ENV=dev # local, dev, production
 ```
 
 ### Generating XMTP Keys

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -181,10 +181,10 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
 To run your XMTP agent, you must create a `.env` file with the following variables:
 
-```tsx
+```bash
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # encryption key for the local database
-XMTP_ENV= # local, dev, production
+XMTP_ENV=dev # local, dev, production
 ```
 
 ### Generating XMTP Keys
@@ -874,7 +874,7 @@ Example package.json for a project that uses XMTP:
 
 ### Web inbox
 
-Interact with the XMTP network using [xmtp.chat](mdc:https:/xmtp.chat), the official web inbox for developers.
+Interact with the XMTP network uschat](https://xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -874,11 +874,11 @@ Example package.json for a project that uses XMTP:
 
 ### Web inbox
 
-Interact with the XMTP network using [https://xmtp.chat](https://xmtp.chat), the official web inbox for developers.
+Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 
-`Dev` and `production` networks are hosted by XMTP, while `local` network is hosted by yourself, so it's faster for development purposes.
+`dev` and `production` networks are hosted by XMTP, while `local` network is hosted by yourself.
 
 - 1. Install docker
 - 2. Start the XMTP service and database

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -874,7 +874,7 @@ Example package.json for a project that uses XMTP:
 
 ### Web inbox
 
-Interact with the XMTP network uschat](https://xmtp.chat), the official web inbox for developers.
+Interact with the XMTP network using [https://xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
-XMTP_ENV=dev # the environment to use, dev, local or production
-
+XMTP_ENV=dev # local, dev, production

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 ```bash
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # encryption key for the local database
-XMTP_ENV= # local, dev, production
+XMTP_ENV=dev # local, dev, production
 ```
 
 You can generate random xmtp keys with the following command:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ yarn dev
 
 ### Work in local network
 
-`Dev` and `production` networks are hosted by XMTP, while `local` network is hosted by yourself, so it's faster for development purposes.
+`dev` and `production` networks are hosted by XMTP, while `local` network is hosted by yourself.
 
 - 1. Install docker
 - 2. Start the XMTP service and database

--- a/examples/xmtp-coinbase-agentkit/.env.example
+++ b/examples/xmtp-coinbase-agentkit/.env.example
@@ -6,4 +6,4 @@ NETWORK_ID=base-sepolia # base-mainnet or others
 OPENAI_API_KEY= # the OpenAI API key  
 CDP_API_KEY_NAME= # the name of the CDP API key
 CDP_API_KEY_PRIVATE_KEY= # the private key for the CDP API key
-XMTP_ENV=local # the environment to use for XMTP
+XMTP_ENV=dev # local, dev, production

--- a/examples/xmtp-coinbase-agentkit/README.md
+++ b/examples/xmtp-coinbase-agentkit/README.md
@@ -31,7 +31,7 @@ NETWORK_ID=base-sepolia # base-mainnet or others
 OPENAI_API_KEY= # the OpenAI API key
 CDP_API_KEY_NAME= # the name of the CDP API key
 CDP_API_KEY_PRIVATE_KEY= # the private key for the CDP API key
-XMTP_ENV=local # local, dev, production
+XMTP_ENV=dev # local, dev, production
 ```
 
 You can generate random xmtp keys with the following command:

--- a/examples/xmtp-coinbase-cdp-group-toss/.env.example
+++ b/examples/xmtp-coinbase-cdp-group-toss/.env.example
@@ -6,4 +6,4 @@ NETWORK_ID=base-sepolia # base-mainnet or others
 OPENAI_API_KEY= # the OpenAI API key  
 CDP_API_KEY_NAME= # the name of the CDP API key
 CDP_API_KEY_PRIVATE_KEY= # the private key for the CDP API key
-XMTP_ENV=local # the environment to use for XMTP
+XMTP_ENV=dev # local, dev, production

--- a/examples/xmtp-coinbase-cdp-group-toss/README.md
+++ b/examples/xmtp-coinbase-cdp-group-toss/README.md
@@ -31,7 +31,7 @@ NETWORK_ID=base-sepolia # base-mainnet or others
 OPENAI_API_KEY= # the OpenAI API key
 CDP_API_KEY_NAME= # the name of the CDP API key
 CDP_API_KEY_PRIVATE_KEY= # the private key for the CDP API key
-XMTP_ENV=local # local, dev, production
+XMTP_ENV=dev # local, dev, production
 ```
 
 You can generate random xmtp keys with the following command:

--- a/examples/xmtp-gaia/.env.example
+++ b/examples/xmtp-gaia/.env.example
@@ -1,5 +1,5 @@
 # XMTP 
-XMTP_ENV=dev # the environment to use, dev, local or production
+XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 0x..

--- a/examples/xmtp-gaia/README.md
+++ b/examples/xmtp-gaia/README.md
@@ -22,7 +22,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 ```bash
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
-XMTP_ENV= # local, dev, production
+XMTP_ENV=dev # local, dev, production
 GAIA_API_KEY= # Your API key from https://gaianet.ai
 GAIA_NODE_URL= # Your custom Gaia node URL or a public node, ex: https://llama8b.gaia.domains/v1
 GAIA_MODEL_NAME= # Model name running in your Gaia node or a public node, ex: llama

--- a/examples/xmtp-gm/.env.example
+++ b/examples/xmtp-gm/.env.example
@@ -1,4 +1,4 @@
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
-XMTP_ENV=dev # the environment to use, dev, local or production
+XMTP_ENV=dev # local, dev, production
 

--- a/examples/xmtp-gm/README.md
+++ b/examples/xmtp-gm/README.md
@@ -22,7 +22,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 ```bash
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # encryption key for the local database
-XMTP_ENV= # local, dev, production
+XMTP_ENV=dev # local, dev, production
 ```
 
 You can generate random xmtp keys with the following command:

--- a/examples/xmtp-gpt/.env.example
+++ b/examples/xmtp-gpt/.env.example
@@ -1,5 +1,5 @@
 # XMTP 
-XMTP_ENV=dev # the environment to use, dev, local or production
+XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 0x..

--- a/examples/xmtp-gpt/README.md
+++ b/examples/xmtp-gpt/README.md
@@ -21,7 +21,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 ```bash
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # encryption key for the local database
-XMTP_ENV= # local, dev, production
+XMTP_ENV=dev # local, dev, production
 OPENAI_API_KEY= # the API key for the OpenAI API
 ```
 

--- a/examples/xmtp-nft-gated-group/.env.example
+++ b/examples/xmtp-nft-gated-group/.env.example
@@ -1,5 +1,5 @@
 # XMTP 
-XMTP_ENV=dev # the environment to use, dev, local or production
+XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 0x..

--- a/examples/xmtp-nft-gated-group/README.md
+++ b/examples/xmtp-nft-gated-group/README.md
@@ -22,7 +22,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 ```bash
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # encryption key for the local database
-XMTP_ENV= # local, dev, production
+XMTP_ENV=dev # local, dev, production
 ALCHEMY_API_KEY= # alchemy api to check NFT ownership
 ```
 


### PR DESCRIPTION
### Set XMTP_ENV default value to 'dev' across all environment configuration files and documentation
Updates environment configuration files and documentation across multiple examples and the main project to:

* Standardize `XMTP_ENV` default value to 'dev' in all `.env.example` files and README documentation
* Normalize comment format for `XMTP_ENV` to consistently show options as 'local, dev, production'
* Fix code block formatting and broken link in [xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/64/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20)

#### 📍Where to Start
Start with the main [.env.example](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/64/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c) file at the root of the project, then review the corresponding changes in example project configurations.

----

_[Macroscope](https://app.macroscope.com) summarized 8185403._