### PR TITLE
Update CDP API key private key formatting in langchain

### DIFF
--- a/examples/xmtp-coinbase-cdp-group-toss/src/langchain.ts
+++ b/examples/xmtp-coinbase-cdp-group-toss/src/langchain.ts
@@ -88,11 +88,11 @@ export async function initializeAgent(inboxId: string) {
         erc20ActionProvider(),
         cdpApiActionProvider({
           apiKeyName: CDP_API_KEY_NAME,
-          apiKeyPrivateKey: CDP_API_KEY_PRIVATE_KEY,
+          apiKeyPrivateKey: CDP_API_KEY_PRIVATE_KEY.replace(/\\n/g, "\n"),
         }),
         cdpWalletActionProvider({
           apiKeyName: CDP_API_KEY_NAME,
-          apiKeyPrivateKey: CDP_API_KEY_PRIVATE_KEY,
+          apiKeyPrivateKey: CDP_API_KEY_PRIVATE_KEY.replace(/\\n/g, "\n"),
         }),
       ],
     });


### PR DESCRIPTION
### Fix newline character handling in CDP API private key formatting within langchain action providers
The code modifies the private key handling in the `cdpApiActionProvider` and `cdpWalletActionProvider` configurations within [langchain.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/67/files#diff-7d9cef0c1cb8963e171a616e7be2e95d089ec9e05ff755e2298d6166be5644bc). The change implements proper newline character conversion by replacing escaped newlines (`\n`) with actual newline characters in the `apiKeyPrivateKey` parameter.

#### 📍Where to Start
Start by reviewing the action providers configuration in [langchain.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/67/files#diff-7d9cef0c1cb8963e171a616e7be2e95d089ec9e05ff755e2298d6166be5644bc) where the `apiKeyPrivateKey` parameter handling is modified.

----

_[Macroscope](https://app.macroscope.com) summarized 9a32cae._