### PR TITLE
Add workflow to check XMTP agent examples

### DIFF
--- a/.github/workflows/check-agent-examples.yml
+++ b/.github/workflows/check-agent-examples.yml
@@ -1,0 +1,49 @@
+name: Check agent-examples
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  run-agent:
+    runs-on: ubuntu-latest
+
+    steps: # sd
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Clone XMTP agent examples
+        run: |
+          git clone https://github.com/ephemeraHQ/xmtp-agent-examples.git
+          cd xmtp-agent-examples
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
+
+      - name: Install dependencies
+        run: |
+          cd xmtp-agent-examples
+          yarn install
+
+      - name: Generate keys
+        run: |
+          cd xmtp-agent-examples
+          yarn gen:keys
+          echo "XMTP_ENV=${{ vars.XMTP_ENV }}" >> .env
+
+      - name: Run agent
+        run: |
+          cd xmtp-agent-examples
+          timeout 20s yarn dev | tee output.log
+          if grep -q "Waiting for messages..." output.log; then
+            echo "Success: Agent started successfully and is waiting for messages"
+            exit 0
+          else
+            echo "Error: Agent did not reach 'Waiting for messages...' state"
+            exit 1
+          fi


### PR DESCRIPTION
### Add GitHub Actions workflow to validate XMTP agent examples functionality hourly
Introduces a new GitHub Actions workflow that runs on an hourly schedule to validate XMTP agent examples. The workflow in [.github/workflows/check-agent-examples.yml](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/71/files#diff-a4fdae9681d99575ca4d0ad0beb8ec84106bf8d2d8cd587b3de9e7d7172360a0) performs the following:

* Clones the XMTP agent examples repository
* Sets up Node.js environment using `.node-version` configuration
* Installs dependencies and generates required keys
* Executes agent with 20-second timeout to verify successful startup state

#### 📍Where to Start
Begin by reviewing the workflow configuration in [.github/workflows/check-agent-examples.yml](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/71/files#diff-a4fdae9681d99575ca4d0ad0beb8ec84106bf8d2d8cd587b3de9e7d7172360a0) which defines the complete validation process.

----

_[Macroscope](https://app.macroscope.com) summarized 62784ce._