### PR TITLE
Update workflow trigger to only run on pull requests

### DIFF
--- a/.github/workflows/check-agent-examples.yml
+++ b/.github/workflows/check-agent-examples.yml
@@ -1,0 +1,49 @@
+name: Check agent-examples
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  run-agent:
+    runs-on: ubuntu-latest
+
+    steps: # sd
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Clone XMTP agent examples
+        run: |
+          git clone https://github.com/ephemeraHQ/xmtp-agent-examples.git
+          cd xmtp-agent-examples
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
+
+      - name: Install dependencies
+        run: |
+          cd xmtp-agent-examples
+          yarn install
+
+      - name: Generate keys
+        run: |
+          cd xmtp-agent-examples
+          yarn gen:keys
+          echo "XMTP_ENV=${{ vars.XMTP_ENV }}" >> .env
+
+      - name: Run agent
+        run: |
+          cd xmtp-agent-examples
+          timeout 20s yarn dev | tee output.log
+          if grep -q "Waiting for messages..." output.log; then
+            echo "Success: Agent started successfully and is waiting for messages"
+            exit 0
+          else
+            echo "Error: Agent did not reach 'Waiting for messages...' state"
+            exit 1
+          fi

--- a/.github/workflows/check-agent-examples.yml
+++ b/.github/workflows/check-agent-examples.yml
@@ -6,14 +6,14 @@ jobs:
   run-agent:
     runs-on: ubuntu-latest
 
-    steps: # sd
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Clone XMTP agent examples
+      - name: Clone into test directory
         run: |
-          git clone https://github.com/ephemeraHQ/xmtp-agent-examples.git
-          cd xmtp-agent-examples
+          git clone . test-dir
+          cd test-dir
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,18 +25,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd xmtp-agent-examples
+          cd test-dir
           yarn install
 
       - name: Generate keys
         run: |
-          cd xmtp-agent-examples
+          cd test-dir
           yarn gen:keys
           echo "XMTP_ENV=${{ vars.XMTP_ENV }}" >> .env
 
       - name: Run agent
         run: |
-          cd xmtp-agent-examples
+          cd test-dir
           timeout 20s yarn dev | tee output.log
           if grep -q "Waiting for messages..." output.log; then
             echo "Success: Agent started successfully and is waiting for messages"

--- a/.github/workflows/check-agent-examples.yml
+++ b/.github/workflows/check-agent-examples.yml
@@ -28,16 +28,16 @@ jobs:
           cd test-dir
           yarn install
 
-      - name: Generate keys
+      - name: Generate keys and set env
         run: |
           cd test-dir
           yarn gen:keys
-          echo "XMTP_ENV=${{ vars.XMTP_ENV }}" >> .env
+          echo "XMTP_ENV=dev" >> .env
 
       - name: Run agent
         run: |
           cd test-dir
-          timeout 20s yarn dev | tee output.log
+          XMTP_ENV=dev timeout 20s yarn dev | tee output.log
           if grep -q "Waiting for messages..." output.log; then
             echo "Success: Agent started successfully and is waiting for messages"
             exit 0

--- a/.github/workflows/check-agent-examples.yml
+++ b/.github/workflows/check-agent-examples.yml
@@ -1,8 +1,6 @@
 name: Check agent-examples
-on:
-  schedule:
-    - cron: "0 * * * *"
-  workflow_dispatch:
+
+on: [pull_request]
 
 jobs:
   run-agent:


### PR DESCRIPTION
### Modify GitHub workflow to execute on pull requests instead of scheduled runs for agent example testing
The workflow configuration in [check-agent-examples.yml](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/72/files#diff-a4fdae9681d99575ca4d0ad0beb8ec84106bf8d2d8cd587b3de9e7d7172360a0) has been updated to:
* Replace scheduled hourly and manual triggers with pull request-based execution
* Clone and test the current repository instead of external `xmtp-agent-examples` repository
* Set `XMTP_ENV` to `dev` explicitly rather than using repository variables

#### 📍Where to Start
Start by reviewing the workflow trigger and environment configuration changes in [check-agent-examples.yml](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/72/files#diff-a4fdae9681d99575ca4d0ad0beb8ec84106bf8d2d8cd587b3de9e7d7172360a0)

----

_[Macroscope](https://app.macroscope.com) summarized 61e6483._