### PR TITLE
Update README with new cursor rules for vibe coding

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -246,7 +246,6 @@ const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 const env: XmtpEnv = process.env.XMTP_ENV as XmtpEnv;
 
 async function main() {
-  console.log(`Creating client on the '${env}' network...`);
   const client = await Client.create(signer, encryptionKey, { env });
 
   console.log("Syncing conversations...");

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -233,7 +233,6 @@ ENCRYPTION_KEY_ALICE=...
 ### Solution:
 
 ```typescript
-
 import { createSigner, getEncryptionKeyFromHex } from "@helpers";
 import { Client, IdentifierKind, type XmtpEnv } from "@xmtp/node-sdk";
 
@@ -252,7 +251,6 @@ const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 const env: XmtpEnv = process.env.XMTP_ENV as XmtpEnv;
 
 async function main() {
-  console.log(`Creating client on the '${env}' network...`);
   const client = await Client.create(signer, encryptionKey, { env });
 
   console.log("Syncing conversations...");
@@ -874,9 +872,7 @@ Example package.json for a project that uses XMTP:
 
 ### Web inbox
 
-Interact with the XMTP network using [xmtp.chat](mdc:https:/xmtp.chat), the official web inbox for developers.
-
-### Work in local network
+Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for dev### Work in local network
 
 `dev` and `production` networks are hosted by XMTP, while `local` network is hosted by yourself.
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This repository contains examples of agents that use the [XMTP](https://docs.xmt
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!IMPORTANT]
+> See our [cursor rules](/.cursor/README.md) for vibe coding.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This repository contains examples of agents that use the [XMTP](https://docs.xmt
 
 ## Getting started
 
-> [!NOTE] Cursor rules
-> See XMTP's [cursor rules](/.cursor/README.md) for agent development best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for agent vibe coding.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains examples of agents that use the [XMTP](https://docs.xmt
 
 ## Getting started
 
-> [!TIP]
+> [!NOTE] Cursor rules
 > See XMTP's [cursor rules](/.cursor/README.md) for agent development best practices.
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains examples of agents that use the [XMTP](https://docs.xmt
 ## Getting started
 
 > [!TIP]
-> See XMTP's [cursor rules](/.cursor/README.md) for agent vibe coding.
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains examples of agents that use the [XMTP](https://docs.xmt
 ## Getting started
 
 > [!TIP]
-> See our [cursor rules](/.cursor/README.md) for vibe coding.
+> See XMTP's [cursor rules](/.cursor/README.md) for agent development best practices.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains examples of agents that use the [XMTP](https://docs.xmt
 
 ## Getting started
 
-> [!IMPORTANT]
+> [!TIP]
 > See our [cursor rules](/.cursor/README.md) for vibe coding.
 
 ### Requirements

--- a/examples/xmtp-coinbase-agentkit/README.md
+++ b/examples/xmtp-coinbase-agentkit/README.md
@@ -6,8 +6,8 @@ This example demonstrates an agent setup on XMTP Network with access to the full
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-coinbase-cdp-group-toss/README.md
+++ b/examples/xmtp-coinbase-cdp-group-toss/README.md
@@ -6,8 +6,8 @@ A coin toss agent built using CDP AgentKit that operates over the XMTP messaging
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-gaia/README.md
+++ b/examples/xmtp-gaia/README.md
@@ -6,8 +6,8 @@ Using Gaia, you can also run your own [node](https://docs.gaianet.ai/getting-sta
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -36,7 +36,6 @@ const openai = new OpenAI({
  * Main function to run the agent
  */
 async function main() {
-  console.log(`Creating client on the '${XMTP_ENV}' network...`);
   /* Initialize the xmtp client */
   const client = await Client.create(signer, encryptionKey, {
     env: XMTP_ENV as XmtpEnv,

--- a/examples/xmtp-gm/README.md
+++ b/examples/xmtp-gm/README.md
@@ -6,8 +6,8 @@ This agent replies `gm`
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -16,7 +16,6 @@ const signer = createSigner(WALLET_KEY);
 const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
 async function main() {
-  console.log(`Creating client on the '${XMTP_ENV}' network...`);
   const client = await Client.create(signer, encryptionKey, {
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-gpt/README.md
+++ b/examples/xmtp-gpt/README.md
@@ -4,8 +4,8 @@ This example uses the [OpenAI](https://openai.com) API for GPT-based responses a
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-gpt/index.ts
+++ b/examples/xmtp-gpt/index.ts
@@ -25,7 +25,6 @@ const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
  * Main function to run the agent
  */
 async function main() {
-  console.log(`Creating client on the '${XMTP_ENV}' network...`);
   /* Initialize the xmtp client */
   const client = await Client.create(signer, encryptionKey, {
     env: XMTP_ENV as XmtpEnv,

--- a/examples/xmtp-nft-gated-group/README.md
+++ b/examples/xmtp-nft-gated-group/README.md
@@ -6,8 +6,8 @@ To create a gated group chat using XMTP, you will need an admin bot within the g
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-nft-gated-group/index.ts
+++ b/examples/xmtp-nft-gated-group/index.ts
@@ -30,7 +30,6 @@ const signer = createSigner(WALLET_KEY);
 const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
 async function main() {
-  console.log(`Creating client on the '${XMTP_ENV}' network...`);
   const client = await Client.create(signer, encryptionKey, {
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-smart-wallet/README.md
+++ b/examples/xmtp-smart-wallet/README.md
@@ -4,8 +4,8 @@ This example demonstrates an agent setup on XMTP Network with access to the full
 
 ## Getting started
 
-> [!NOTE]
-> See our [Cursor Rules](/.cursor/README.md) for XMTP Agent development standards and best practices.
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -33,7 +33,6 @@ const identifier = await signer.getIdentifier();
 const address = identifier.identifier;
 console.log(`Smart Wallet Address: ${address}`);
 const main = async () => {
-  console.log(`Creating client on the '${XMTP_ENV}' network...`);
   const client = await Client.create(signer, encryptionKey, {
     env: XMTP_ENV as XmtpEnv,
   });

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -37,6 +37,7 @@ export const logAgentDetails = (
     `║ 📍 Address: ${address}${" ".repeat(maxLengthWithDbPath - address.length - 15)}║`,
     `║ 📍 inboxId: ${inboxId}${" ".repeat(maxLengthWithDbPath - inboxId.length - 15)}║`,
     `║ 📂 DB Path: ${dbPath}${" ".repeat(maxLengthWithDbPath - dbPath.length - 15)}║`,
+    `║ 🛜  Network: ${env}${" ".repeat(maxLengthWithDbPath - env.length - 15)}║`,
     `║ 🔗 URL: ${url}${" ".repeat(maxLengthWithDbPath - url.length - 11)}║`,
     `╚${createLine(maxLengthWithDbPath)}╝`,
   ].join("\n");


### PR DESCRIPTION
### Update documentation and remove debug logging to align with XMTP's cursor rules
* Removed `console.log` statements that logged client creation network environment from multiple files including [.cursor/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/76/files#diff-c97b2d176b8c1829957fd2a6eae94d16b8d74a0937e6fe670aaac658ce3f2e27) and example implementations
* Updated documentation styling by changing `[!NOTE]` callouts to `[!TIP]` and standardized references to "cursor rules" in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/76/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and example READMEs
* Fixed URL format in [.cursor/rules/xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/76/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20) from `mdc:https:/xmtp.chat` to `https://xmtp.chat`
* Added network environment display to agent details box in [helpers/utils.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/76/files#diff-253d326c009147a6c4c0327e9e16f4d7fee7b150c2dbadad50f41f8b530b47cd)

#### 📍Where to Start
Start with the documentation changes in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/76/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) as it contains the core changes to cursor rules references, then review the debug logging removals in the example implementation files.

----

_[Macroscope](https://app.macroscope.com) summarized 14c187e._