### PR TITLE
Update @xmtp/node-sdk to version 1.1.1

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -256,7 +256,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```json
     {
       "dependencies": {
-        "@xmtp/node-sdk": "1.0.5"
+        "@xmtp/node-sdk": "1.1.1"
         /* other dependencies */
       }
     }
@@ -303,7 +303,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
         "start": "tsx index.ts"
       },
       "dependencies": {
-        "@xmtp/node-sdk": "1.0.5"
+        "@xmtp/node-sdk": "1.1.1"
       },
       "devDependencies": {
         "tsx": "^4.19.2",

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -487,13 +487,7 @@ async function main() {
   }
 }
 
-main().catch((error: unknown) => {
-  console.error(
-    "Unhandled error:",
-    error instanceof Error ? error.message : String(error),
-  );
-  process.exit(1);
-});
+main().catch(console.error);
 ```
 
 ## XMTP Helper Functions

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -492,13 +492,7 @@ async function main() {
   }
 }
 
-main().catch((error: unknown) => {
-  console.error(
-    "Unhandled error:",
-    error instanceof Error ? error.message : String(error),
-  );
-  process.exit(1);
-});
+main().catch(console.error);
 ```
 
 ## XMTP Helper Functions
@@ -943,7 +937,7 @@ if (!fs.existsSync(dbPath)) {
 
 ### Web inbox
 
-Interact with the XMTP network using [xmtp.chat]mtp.chat), the official web inbox for developers.
+Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -261,7 +261,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```json
     {
       "dependencies": {
-        "@xmtp/node-sdk": "1.0.5"
+        "@xmtp/node-sdk": "1.1.1"
         /* other dependencies */
       }
     }
@@ -308,7 +308,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
         "start": "tsx index.ts"
       },
       "dependencies": {
-        "@xmtp/node-sdk": "1.0.5"
+        "@xmtp/node-sdk": "1.1.1"
       },
       "devDependencies": {
         "tsx": "^4.19.2",

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -326,7 +326,4 @@ async function main(): Promise<void> {
 }
 
 // Start the chatbot
-main().catch((error: unknown) => {
-  console.error("Fatal error:", error);
-  process.exit(1);
-});
+main().catch(console.error);

--- a/examples/xmtp-coinbase-agentkit/package.json
+++ b/examples/xmtp-coinbase-agentkit/package.json
@@ -16,7 +16,7 @@
     "@langchain/core": "^0.3.19",
     "@langchain/langgraph": "^0.2.21",
     "@langchain/openai": "^0.3.14",
-    "@xmtp/node-sdk": "1.0.5"
+    "@xmtp/node-sdk": "1.1.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-gaia/package.json
+++ b/examples/xmtp-gaia/package.json
@@ -11,7 +11,7 @@
     "start": "tsx  index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.0.5",
+    "@xmtp/node-sdk": "1.1.1",
     "openai": "latest"
   },
   "devDependencies": {

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -58,10 +58,4 @@ async function main() {
   }
 }
 
-main().catch((error: unknown) => {
-  console.error(
-    "Unhandled error:",
-    error instanceof Error ? error.message : String(error),
-  );
-  process.exit(1);
-});
+main().catch(console.error);

--- a/examples/xmtp-gm/package.json
+++ b/examples/xmtp-gm/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.0.5"
+    "@xmtp/node-sdk": "1.1.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-gpt/package.json
+++ b/examples/xmtp-gpt/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.0.5",
+    "@xmtp/node-sdk": "1.1.1",
     "openai": "latest"
   },
   "devDependencies": {

--- a/examples/xmtp-group-toss/package.json
+++ b/examples/xmtp-group-toss/package.json
@@ -17,7 +17,7 @@
     "@langchain/core": "^0.3.20",
     "@langchain/langgraph": "^0.2.24",
     "@langchain/openai": "^0.3.14",
-    "@xmtp/node-sdk": "1.0.5"
+    "@xmtp/node-sdk": "1.1.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-multiple-clients/index.ts
+++ b/examples/xmtp-multiple-clients/index.ts
@@ -128,10 +128,4 @@ async function main(): Promise<void> {
 }
 
 // Run the main function
-main().catch((error: unknown) => {
-  console.error(
-    "Unhandled error:",
-    error instanceof Error ? error.message : String(error),
-  );
-  process.exit(1);
-});
+main().catch(console.error);

--- a/examples/xmtp-multiple-clients/package.json
+++ b/examples/xmtp-multiple-clients/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.0.5"
+    "@xmtp/node-sdk": "1.1.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-nft-gated-group/package.json
+++ b/examples/xmtp-nft-gated-group/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.0.5",
+    "@xmtp/node-sdk": "1.1.1",
     "alchemy-sdk": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -118,10 +118,4 @@ async function initializeWallet(walletPath: string): Promise<WalletData> {
   }
 }
 
-main().catch((error: unknown) => {
-  console.error(
-    "Unhandled error:",
-    error instanceof Error ? error.message : String(error),
-  );
-  process.exit(1);
-});
+main().catch(console.error);

--- a/examples/xmtp-smart-wallet/package.json
+++ b/examples/xmtp-smart-wallet/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/coinbase-sdk": "latest",
-    "@xmtp/node-sdk": "1.0.5"
+    "@xmtp/node-sdk": "1.1.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-transaction-content-type/package.json
+++ b/examples/xmtp-transaction-content-type/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@xmtp/content-type-transaction-reference": "^2.0.1",
     "@xmtp/content-type-wallet-send-calls": "^1.0.0",
-    "@xmtp/node-sdk": "1.0.5"
+    "@xmtp/node-sdk": "1.1.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.0.5",
+    "@xmtp/node-sdk": "1.1.1",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,7 +928,7 @@ __metadata:
     "@langchain/core": "npm:^0.3.19"
     "@langchain/langgraph": "npm:^0.2.21"
     "@langchain/openai": "npm:^0.3.14"
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -938,7 +938,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gaia@workspace:examples/xmtp-gaia"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     openai: "npm:latest"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -949,7 +949,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gm@workspace:examples/xmtp-gm"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -959,7 +959,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gpt@workspace:examples/xmtp-gpt"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     openai: "npm:latest"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -975,7 +975,7 @@ __metadata:
     "@langchain/core": "npm:^0.3.20"
     "@langchain/langgraph": "npm:^0.2.24"
     "@langchain/openai": "npm:^0.3.14"
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -985,7 +985,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-multiple-clients@workspace:examples/xmtp-multiple-clients"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -995,7 +995,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-nft-gated-group@workspace:examples/xmtp-nft-gated-group"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     alchemy-sdk: "npm:^3.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -1007,7 +1007,7 @@ __metadata:
   resolution: "@examples/xmtp-smart-wallet@workspace:examples/xmtp-smart-wallet"
   dependencies:
     "@coinbase/coinbase-sdk": "npm:latest"
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -1019,7 +1019,7 @@ __metadata:
   dependencies:
     "@xmtp/content-type-transaction-reference": "npm:^2.0.1"
     "@xmtp/content-type-wallet-send-calls": "npm:^1.0.0"
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -1955,23 +1955,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@xmtp/node-bindings@npm:1.1.3"
-  checksum: 10/729473bbb36fcc0da5a700aad65e2ef2441639591ae091a35c605d1294dfac7c7201b0504706d78bc8cabcd7f6473245ed0018c65e92d78e8eaf3b741b87c6fd
+"@xmtp/node-bindings@npm:^1.2.0-dev.bed98df":
+  version: 1.2.0-dev.bed98df
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.bed98df"
+  checksum: 10/a7e57fb3a1fa462ba49be33ad4ec05e3f164cfd198b5011a12968e57f477abe822c754a74a6fb7b529789408caee38ed1291e1e0165b4f5f3969e50ce98d1e15
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:1.0.5":
-  version: 1.0.5
-  resolution: "@xmtp/node-sdk@npm:1.0.5"
+"@xmtp/node-sdk@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@xmtp/node-sdk@npm:1.1.1"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.1"
     "@xmtp/content-type-primitives": "npm:^2.0.1"
     "@xmtp/content-type-text": "npm:^2.0.1"
-    "@xmtp/node-bindings": "npm:^1.1.3"
+    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
     "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/87218dff16686d9afe3431b186d6f2ba7d898501a39ebd02cf6305aba8fe3dfa4aaeeba07e79c07345cbd37f449c354069ae90d0e07d42bc95a60fc602a2742e
+  checksum: 10/bee8f34281ffa25cc638d83d6eecd66009882d40cfe7be6845a178181bf6545a4e19891bfe01b3cefe76ee320a33f3033dbbcea4cce9ea9172cc2899b1917dfa
   languageName: node
   linkType: hard
 
@@ -5543,7 +5543,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"


### PR DESCRIPTION
### Upgrade @xmtp/node-sdk from version 1.0.5 to 1.1.1 across all example projects and documentation
* Updated `@xmtp/node-sdk` dependency from version 1.0.5 to 1.1.1 in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/88/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and all example project configurations
* Simplified error handling patterns in example projects by replacing verbose custom error formatting and `process.exit(1)` calls with `console.error`
* Fixed URL formatting in Web inbox documentation section in [xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/88/files#diff-d8ff5adab0f0a454efe4f5c065d94fca9c93d6ba6c67be11457f9daf2388d8f2)

#### 📍Where to Start
Start with the dependency version update in the root [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/88/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), then review the error handling changes in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/88/files#diff-b7bfbea16a422f169ef1ed3b4d8a2ce445a4e156099da3c36089bf91b538e752) which exemplifies the pattern applied across multiple example projects.

----

_[Macroscope](https://app.macroscope.com) summarized 0dd21e4._