### PR TITLE
Fix package version in all examples + Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ main().catch(console.error);
 - [xmtp-group-toss](/examples/xmtp-group-toss/): Agent that uses a group to toss a coin
 - [xmtp-gaia](/examples/xmtp-gaia/): Agent that uses a CDP for gassless USDC on base
 - [xmtp-smart-wallet](/examples/xmtp-smart-wallet/): Agent that uses a smart wallet to send messages
-- [xmtp-multiple-clients](/examples/xmtp-multiple-clients/): Agent that uses multiple clients to send messages
+- [xmtp-multiple-clients](/examples/xmtp-multiple-clients/): Parallel agents listening and sending messages
+- [xmtp-attachment-content-type](/examples/xmtp-attachment-content-type/): Agent that sends images
 
 ## Web inbox
 

--- a/examples/xmtp-attachment-content-type/README.md
+++ b/examples/xmtp-attachment-content-type/README.md
@@ -13,6 +13,7 @@ This agent replies with an attachment.
 - Yarn v4 or higher
 - Docker (optional, for local network)
 - [Pinata API key](https://app.pinata.cloud/developers/api-keys)
+- [@xmtp/content-type-remote-attachment](https://github.com/xmtp/xmtp-js/tree/main/content-types/content-type-remote-attachment)
 
 ### Environment variables
 

--- a/examples/xmtp-attachment-content-type/package.json
+++ b/examples/xmtp-attachment-content-type/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-remote-attachment": "^2.0.1",
-    "@xmtp/node-sdk": "1.0.5",
+    "@xmtp/node-sdk": "1.1.1",
     "axios": "^1.8.4",
     "form-data": "^4.0.2"
   },

--- a/examples/xmtp-transaction-content-type/README.md
+++ b/examples/xmtp-transaction-content-type/README.md
@@ -53,7 +53,7 @@ yarn gen:keys
 git clone https://github.com/ephemeraHQ/xmtp-agent-examples.git
 # go to the folder
 cd xmtp-agent-examples
-cd examples/transaction
+cd examples/xmtp-transaction-content-type
 # install packages
 yarn
 # generate random xmtp keys (optional)

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,7 +925,7 @@ __metadata:
   resolution: "@examples/xmtp-attachment-content-type@workspace:examples/xmtp-attachment-content-type"
   dependencies:
     "@xmtp/content-type-remote-attachment": "npm:^2.0.1"
-    "@xmtp/node-sdk": "npm:1.0.5"
+    "@xmtp/node-sdk": "npm:1.1.1"
     axios: "npm:^1.8.4"
     form-data: "npm:^4.0.2"
     tsx: "npm:^4.19.2"


### PR DESCRIPTION
### Update documentation and dependencies to support new attachment agent functionality in XMTP examples
* Updates [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/92/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with revised description for `xmtp-multiple-clients` example and adds new `xmtp-attachment-content-type` example
* Adds `@xmtp/content-type-remote-attachment` dependency requirement in [examples/xmtp-attachment-content-type/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/92/files#diff-9050a2c8c0ffee39559082aecb181be1d5a51716fa4ce11e298b57edf2b32a72)
* Upgrades `@xmtp/node-sdk` from version 1.0.5 to 1.1.1 in [examples/xmtp-attachment-content-type/package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/92/files#diff-8cf1a0b570e60e6dd36a2dff6aa371ce82d0fe64cff2f1fb315d3de0d0336978)
* Fixes installation path in [examples/xmtp-transaction-content-type/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/92/files#diff-cd95e42658c0b472ab700122019f6a1c9a60e5d164aa1189c716497b5ad390d1)

#### 📍Where to Start
Start with the main [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/92/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) which contains the high-level changes to the example descriptions and new example addition.

----

_[Macroscope](https://app.macroscope.com) summarized 77a07b9._