### PR TITLE
Update xmtp link format for consistency and clarity

### DIFF
--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -937,7 +937,7 @@ if (!fs.existsSync(dbPath)) {
 
 ### Web inbox
 
-Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
+Interact with the XMTP network using [xmtp.chat](mdc:https:/xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,9 @@ You can generate random xmtp keys with the following command:
 ```bash
 # From the root directory (appends to root .env)
 yarn gen:keys
-
-# From within an example directory (creates .env in that directory)
-cd examples/xmtp-number-multiplier
-yarn gen:keys
 ```
 
 > [!WARNING]
-> Running the `gen:keys` command from the root directory will append keys to your existing `.env` file.
 > Running the `gen:keys` command from within an example directory will create a new `.env` file in that directory.
 
 ### Run the agent


### PR DESCRIPTION
### Modify xmtp.chat URL format to use mdc: prefix and update key generation documentation
* Updates the link format in [xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/96/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20) from standard markdown to use `mdc:` prefix: `[xmtp.chat](mdc:https:/xmtp.chat)`
* Streamlines key generation documentation in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/96/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) by removing example directory-specific instructions and clarifying `.env` file creation warnings

#### 📍Where to Start
Begin with reviewing the URL format changes in [xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/96/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20), as this contains the core formatting changes that affect link processing.

----

_[Macroscope](https://app.macroscope.com) summarized 298d13b._