### PR TITLE
Update @xmtp/node-sdk to version 2.0.0 for improvements

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -256,7 +256,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```json
     {
       "dependencies": {
-        "@xmtp/node-sdk": "1.2.1"
+        "@xmtp/node-sdk": "2.0.0"
         /* other dependencies */
       }
     }
@@ -303,7 +303,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
         "start": "tsx index.ts"
       },
       "dependencies": {
-        "@xmtp/node-sdk": "1.2.1"
+        "@xmtp/node-sdk": "2.0.0"
       },
       "devDependencies": {
         "tsx": "^4.19.2",

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -6,7 +6,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
 1.  Use modern TypeScript patterns and ESM modules. All examples should be structured as ES modules with `import` statements rather than CommonJS `require()`.
 
-2.  Use the XMTP node-sdk v1.2.0 or newer, which offers enhanced functionality including group conversations.
+2.  Use the XMTP node-sdk version "2.0.0" or newer, which offers enhanced functionality including group conversations.
 
 3.  Only import from @xmtp/node-sdk for XMTP functionality. Do not import from any other XMTP-related packages or URLs. Specifically:
 
@@ -341,20 +341,16 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
 // Define the address to always add to new groups
 const MEMBER_ADDRESS = "0x7c40611372d354799d138542e77243c284e460b2";
 
-// Initialize client
-const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
 async function main() {
-  const client = await Client.create(signer, encryptionKey, {
+  // Initialize client
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
-  // Log connection details
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   console.log("✓ Syncing conversations...");
   /* Sync the conversations from the network to update the local db */

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -261,7 +261,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```json
     {
       "dependencies": {
-        "@xmtp/node-sdk": "1.2.1"
+        "@xmtp/node-sdk": "2.0.0"
         /* other dependencies */
       }
     }
@@ -308,7 +308,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
         "start": "tsx index.ts"
       },
       "dependencies": {
-        "@xmtp/node-sdk": "1.2.1"
+        "@xmtp/node-sdk": "2.0.0"
       },
       "devDependencies": {
         "tsx": "^4.19.2",

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -11,7 +11,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
 1.  Use modern TypeScript patterns and ESM modules. All examples should be structured as ES modules with `import` statements rather than CommonJS `require()`.
 
-2.  Use the XMTP node-sdk v1.2.0 or newer, which offers enhanced functionality including group conversations.
+2.  Use the XMTP node-sdk version "2.0.0" or newer, which offers enhanced functionality including group conversations.
 
 3.  Only import from @xmtp/node-sdk for XMTP functionality. Do not import from any other XMTP-related packages or URLs. Specifically:
 
@@ -351,15 +351,12 @@ const signer = createSigner(WALLET_KEY);
 const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
 async function main() {
-  const client = await Client.create(signer, encryptionKey, {
+  const client = await Client.create(signer, {
+    dbEncryptionKey: encryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
-  // Log connection details
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   console.log("✓ Syncing conversations...");
   /* Sync the conversations from the network to update the local db */
@@ -937,7 +934,7 @@ if (!fs.existsSync(dbPath)) {
 
 ### Web inbox
 
-Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
+Interact with the XMTP netwoxmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 

--- a/.github/workflows/check-agent-examples.yml
+++ b/.github/workflows/check-agent-examples.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Clone into test directory
         run: |

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -1,12 +1,20 @@
 name: Validate code quality
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "**"
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -1,11 +1,6 @@
 name: Validate code quality
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - "**"
+on: [pull_request]
 
 jobs:
   check:

--- a/examples/xmtp-attachment-content-type/index.ts
+++ b/examples/xmtp-attachment-content-type/index.ts
@@ -19,7 +19,7 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
 ]);
 
 const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
 const DEFAULT_IMAGE_PATH = "./logo.png";
 
@@ -62,14 +62,13 @@ async function createRemoteAttachment(
 }
 
 async function main() {
-  const client = await Client.create(signer, encryptionKey, {
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
     codecs: [new RemoteAttachmentCodec(), new AttachmentCodec()],
   });
 
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   console.log("✓ Syncing conversations...");
   await client.conversations.sync();

--- a/examples/xmtp-attachment-content-type/package.json
+++ b/examples/xmtp-attachment-content-type/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-remote-attachment": "^2.0.1",
-    "@xmtp/node-sdk": "1.2.1",
+    "@xmtp/node-sdk": "2.0.0",
     "axios": "^1.8.4",
     "form-data": "^4.0.2"
   },

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -107,17 +107,18 @@ function getWalletData(userId: string): string | null {
  */
 async function initializeXmtpClient() {
   const signer = createSigner(WALLET_KEY);
-  const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
   const identifier = await signer.getIdentifier();
   const address = identifier.identifier;
 
-  const client = await Client.create(signer, encryptionKey, {
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
     dbPath: XMTP_STORAGE_DIR + `/${XMTP_ENV}-${address}`,
   });
 
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   /* Sync the conversations from the network to update the local db */
   console.log("✓ Syncing conversations...");

--- a/examples/xmtp-coinbase-agentkit/package.json
+++ b/examples/xmtp-coinbase-agentkit/package.json
@@ -16,7 +16,7 @@
     "@langchain/core": "^0.3.19",
     "@langchain/langgraph": "^0.2.21",
     "@langchain/openai": "^0.3.14",
-    "@xmtp/node-sdk": "1.2.1"
+    "@xmtp/node-sdk": "2.0.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -22,10 +22,6 @@ const {
   "GAIA_MODEL_NAME",
 ]);
 
-/* Create the signer using viem and parse the encryption key for the local db */
-const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
 /* Initialize the OpenAI client */
 const openai = new OpenAI({
   baseURL: GAIA_NODE_URL,
@@ -36,14 +32,16 @@ const openai = new OpenAI({
  * Main function to run the agent
  */
 async function main() {
-  /* Initialize the xmtp client */
-  const client = await Client.create(signer, encryptionKey, {
+  /* Create the signer using viem and parse the encryption key for the local db */
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   /* Sync the conversations from the network to update the local db */
   console.log("✓ Syncing conversations...");

--- a/examples/xmtp-gaia/package.json
+++ b/examples/xmtp-gaia/package.json
@@ -11,7 +11,7 @@
     "start": "tsx  index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.2.1",
+    "@xmtp/node-sdk": "2.0.0",
     "openai": "latest"
   },
   "devDependencies": {

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -13,16 +13,14 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
 
 /* Create the signer using viem and parse the encryption key for the local db */
 const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
 async function main() {
-  const client = await Client.create(signer, encryptionKey, {
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
-
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   console.log("✓ Syncing conversations...");
   await client.conversations.sync();

--- a/examples/xmtp-gm/package.json
+++ b/examples/xmtp-gm/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.2.1"
+    "@xmtp/node-sdk": "2.0.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-gpt/index.ts
+++ b/examples/xmtp-gpt/index.ts
@@ -14,10 +14,6 @@ const { WALLET_KEY, ENCRYPTION_KEY, OPENAI_API_KEY, XMTP_ENV } =
     "XMTP_ENV",
   ]);
 
-/* Create the signer using viem and parse the encryption key for the local db */
-const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
 /* Initialize the OpenAI client */
 const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
@@ -25,14 +21,16 @@ const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
  * Main function to run the agent
  */
 async function main() {
-  /* Initialize the xmtp client */
-  const client = await Client.create(signer, encryptionKey, {
+  /* Create the signer using viem and parse the encryption key for the local db */
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   /* Sync the conversations from the network to update the local db */
   console.log("✓ Syncing conversations...");

--- a/examples/xmtp-gpt/package.json
+++ b/examples/xmtp-gpt/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.2.1",
+    "@xmtp/node-sdk": "2.0.0",
     "openai": "latest"
   },
   "devDependencies": {

--- a/examples/xmtp-multiple-clients/package.json
+++ b/examples/xmtp-multiple-clients/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.2.1"
+    "@xmtp/node-sdk": "2.0.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-multiple-clients/workers.ts
+++ b/examples/xmtp-multiple-clients/workers.ts
@@ -53,10 +53,11 @@ export class XmtpWorkerManager {
 
     // Create signer and encryption key
     const signer = createSigner(config.walletKey);
-    const encryptionKey = getEncryptionKeyFromHex(config.encryptionKey);
+    const dbEncryptionKey = getEncryptionKeyFromHex(config.encryptionKey);
 
     // Create XMTP client
-    const client = await Client.create(signer, encryptionKey, {
+    const client = await Client.create(signer, {
+      dbEncryptionKey,
       env: config.xmtpEnv,
     });
 

--- a/examples/xmtp-nft-gated-group/index.ts
+++ b/examples/xmtp-nft-gated-group/index.ts
@@ -25,21 +25,20 @@ const settings = {
   network: Network.BASE_MAINNET,
 };
 
-/* Create the signer using viem and parse the encryption key for the local db */
-const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
 async function main() {
-  const client = await Client.create(signer, encryptionKey, {
+  /* Create the signer using viem and parse the encryption key for the local db */
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
   console.log("✓ Syncing conversations...");
   await client.conversations.sync();
 
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   console.log("Waiting for messages...");
   const stream = await client.conversations.streamAllMessages();

--- a/examples/xmtp-nft-gated-group/package.json
+++ b/examples/xmtp-nft-gated-group/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.2.1",
+    "@xmtp/node-sdk": "2.0.0",
     "alchemy-sdk": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -23,23 +23,18 @@ const {
   "CDP_API_KEY_PRIVATE_KEY",
 ]);
 
-const walletData = await initializeWallet(WALLET_PATH);
-/* Create the signer using viem and parse the encryption key for the local db */
-const signer = createSigner(walletData.seed || "");
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
-// Log connection details
-const identifier = await signer.getIdentifier();
-const address = identifier.identifier;
-console.log(`Smart Wallet Address: ${address}`);
 const main = async () => {
-  const client = await Client.create(signer, encryptionKey, {
+  const walletData = await initializeWallet(WALLET_PATH);
+  /* Create the signer using viem and parse the encryption key for the local db */
+  const signer = createSigner(walletData.seed);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   /* Sync the conversations from the network to update the local db */
   console.log("✓ Syncing conversations...");

--- a/examples/xmtp-smart-wallet/package.json
+++ b/examples/xmtp-smart-wallet/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/coinbase-sdk": "latest",
-    "@xmtp/node-sdk": "1.2.1"
+    "@xmtp/node-sdk": "2.0.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-stream-restart/index.ts
+++ b/examples/xmtp-stream-restart/index.ts
@@ -11,18 +11,17 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
   "XMTP_ENV",
 ]);
 
-/* Create the signer using viem and parse the encryption key for the local db */
-const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
 async function main() {
-  const client = await Client.create(signer, encryptionKey, {
+  /* Create the signer using viem and parse the encryption key for the local db */
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
-  const identifier = await signer.getIdentifier();
-  const address = identifier.identifier;
-  logAgentDetails(address, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   console.log("✓ Syncing conversations...");
   await client.conversations.sync();

--- a/examples/xmtp-stream-restart/package.json
+++ b/examples/xmtp-stream-restart/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.2.1"
+    "@xmtp/node-sdk": "2.0.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-stream-restart/package.json
+++ b/examples/xmtp-stream-restart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/xmtp-stream-restart",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/xmtp-transaction-content-type/index.ts
+++ b/examples/xmtp-transaction-content-type/index.ts
@@ -17,20 +17,20 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
   "XMTP_ENV",
 ]);
 
-/* Create the signer using viem and parse the encryption key for the local db */
-const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
 async function main() {
+  /* Create the signer using viem and parse the encryption key for the local db */
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
   /* Initialize the xmtp client */
-  const client = await Client.create(signer, encryptionKey, {
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
     codecs: [new WalletSendCallsCodec(), new TransactionReferenceCodec()],
   });
 
   const identifier = await signer.getIdentifier();
   const agentAddress = identifier.identifier;
-  logAgentDetails(agentAddress, client.inboxId, XMTP_ENV);
+  logAgentDetails(client);
 
   /* Sync the conversations from the network to update the local db */
   console.log("✓ Syncing conversations...");

--- a/examples/xmtp-transaction-content-type/package.json
+++ b/examples/xmtp-transaction-content-type/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@xmtp/content-type-transaction-reference": "^2.0.1",
     "@xmtp/content-type-wallet-send-calls": "^1.0.0",
-    "@xmtp/node-sdk": "1.2.1"
+    "@xmtp/node-sdk": "2.0.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -1,10 +1,10 @@
+import type { Client } from "@xmtp/node-sdk";
 import "dotenv/config";
 
-export const logAgentDetails = (
-  address: string,
-  inboxId: string,
-  env: string,
-) => {
+export const logAgentDetails = (client: Client) => {
+  const address = client.accountIdentifier?.identifier ?? "";
+  const inboxId = client.inboxId;
+  const env = client.options?.env ?? "dev";
   const createLine = (length: number, char = "═"): string =>
     char.repeat(length - 2);
   const centerText = (text: string, width: number): string => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "1.2.1",
+    "@xmtp/node-sdk": "2.0.0",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,6 +983,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@examples/xmtp-stream-restart@workspace:examples/xmtp-stream-restart":
+  version: 0.0.0-use.local
+  resolution: "@examples/xmtp-stream-restart@workspace:examples/xmtp-stream-restart"
+  dependencies:
+    "@xmtp/node-sdk": "npm:1.2.1"
+    tsx: "npm:^4.19.2"
+    typescript: "npm:^5.7.3"
+  languageName: unknown
+  linkType: soft
+
 "@examples/xmtp-transaction-content-type@workspace:examples/xmtp-transaction-content-type":
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-transaction-content-type@workspace:examples/xmtp-transaction-content-type"

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,7 +896,7 @@ __metadata:
   resolution: "@examples/xmtp-attachment-content-type@workspace:examples/xmtp-attachment-content-type"
   dependencies:
     "@xmtp/content-type-remote-attachment": "npm:^2.0.1"
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     axios: "npm:^1.8.4"
     form-data: "npm:^4.0.2"
     tsx: "npm:^4.19.2"
@@ -913,7 +913,7 @@ __metadata:
     "@langchain/core": "npm:^0.3.19"
     "@langchain/langgraph": "npm:^0.2.21"
     "@langchain/openai": "npm:^0.3.14"
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -923,7 +923,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gaia@workspace:examples/xmtp-gaia"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     openai: "npm:latest"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -934,7 +934,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gm@workspace:examples/xmtp-gm"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -944,7 +944,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gpt@workspace:examples/xmtp-gpt"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     openai: "npm:latest"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -955,7 +955,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-multiple-clients@workspace:examples/xmtp-multiple-clients"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -965,7 +965,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-nft-gated-group@workspace:examples/xmtp-nft-gated-group"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     alchemy-sdk: "npm:^3.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -977,7 +977,7 @@ __metadata:
   resolution: "@examples/xmtp-smart-wallet@workspace:examples/xmtp-smart-wallet"
   dependencies:
     "@coinbase/coinbase-sdk": "npm:latest"
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -987,7 +987,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-stream-restart@workspace:examples/xmtp-stream-restart"
   dependencies:
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -999,7 +999,7 @@ __metadata:
   dependencies:
     "@xmtp/content-type-transaction-reference": "npm:^2.0.1"
     "@xmtp/content-type-wallet-send-calls": "npm:^1.0.0"
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -1980,19 +1980,6 @@ __metadata:
   version: 1.2.0-dev.bed98df
   resolution: "@xmtp/node-bindings@npm:1.2.0-dev.bed98df"
   checksum: 10/a7e57fb3a1fa462ba49be33ad4ec05e3f164cfd198b5011a12968e57f477abe822c754a74a6fb7b529789408caee38ed1291e1e0165b4f5f3969e50ce98d1e15
-  languageName: node
-  linkType: hard
-
-"@xmtp/node-sdk@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@xmtp/node-sdk@npm:1.2.1"
-  dependencies:
-    "@xmtp/content-type-group-updated": "npm:^2.0.1"
-    "@xmtp/content-type-primitives": "npm:^2.0.1"
-    "@xmtp/content-type-text": "npm:^2.0.1"
-    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
-    "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/7c42a7b52bb966432e9c695ed9fa14c96716ef870bf0e9429e7b2a4593748153af170f1152ab7fd37f516783b2f62b83aa1062e411180c8c661baba519ebf81a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,6 +1996,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/node-sdk@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@xmtp/node-sdk@npm:2.0.0"
+  dependencies:
+    "@xmtp/content-type-group-updated": "npm:^2.0.1"
+    "@xmtp/content-type-primitives": "npm:^2.0.1"
+    "@xmtp/content-type-text": "npm:^2.0.1"
+    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
+    "@xmtp/proto": "npm:^3.78.0"
+  checksum: 10/c220be1ee441a255896754ebd0030ba528935f82fb7b59cf9ba3de32acc4312354d2a2258a34b2730decbac3ea05bbd0a257799bddb80cbf2b03d5c74934db9d
+  languageName: node
+  linkType: hard
+
 "@xmtp/proto@npm:^3.78.0":
   version: 3.78.0
   resolution: "@xmtp/proto@npm:3.78.0"
@@ -5587,7 +5600,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:1.2.1"
+    "@xmtp/node-sdk": "npm:2.0.0"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -397,13 +397,13 @@ __metadata:
   linkType: hard
 
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
-  version: 4.5.1
-  resolution: "@eslint-community/eslint-utils@npm:4.5.1"
+  version: 4.6.0
+  resolution: "@eslint-community/eslint-utils@npm:4.6.0"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10/336b85150cf1828cba5b1fcf694233b947e635654c33aa2c1692dc9522d617218dff5abf3aaa6410b92fcb7fd1f0bf5393ec5b588987ac8835860465f8808ec5
+  checksum: 10/f81d40d69ea83616f7ea38c6c45ce55d3cf76d80f91d5c01cc361699ae1951b8678f3627d693b3d4bc062bd35d459be9290c6f796744e09e64161a57497fe446
   languageName: node
   linkType: hard
 
@@ -1161,14 +1161,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@langchain/langgraph-checkpoint@npm:~0.0.16":
-  version: 0.0.16
-  resolution: "@langchain/langgraph-checkpoint@npm:0.0.16"
+"@langchain/langgraph-checkpoint@npm:~0.0.17":
+  version: 0.0.17
+  resolution: "@langchain/langgraph-checkpoint@npm:0.0.17"
   dependencies:
     uuid: "npm:^10.0.0"
   peerDependencies:
     "@langchain/core": ">=0.2.31 <0.4.0"
-  checksum: 10/4dd2978274706409d0a49b6104d40dfa1c538c355316f4e12a9af317c46ae84643882daec453b658c057e70d2300bb4a9414f94f0e50cdf72bb1f7309e238969
+  checksum: 10/298da86f80e010a30772c11b70e7c4cbfeee9cfa0d9e1f71182a4dde0e5b4ee8d2309b30792d2439af34fa5ac1d02b72e105d21c5813644c02f8cb9fa6501314
   languageName: node
   linkType: hard
 
@@ -1193,10 +1193,10 @@ __metadata:
   linkType: hard
 
 "@langchain/langgraph@npm:^0.2.21":
-  version: 0.2.63
-  resolution: "@langchain/langgraph@npm:0.2.63"
+  version: 0.2.64
+  resolution: "@langchain/langgraph@npm:0.2.64"
   dependencies:
-    "@langchain/langgraph-checkpoint": "npm:~0.0.16"
+    "@langchain/langgraph-checkpoint": "npm:~0.0.17"
     "@langchain/langgraph-sdk": "npm:~0.0.32"
     uuid: "npm:^10.0.0"
     zod: "npm:^3.23.8"
@@ -1206,7 +1206,7 @@ __metadata:
   peerDependenciesMeta:
     zod-to-json-schema:
       optional: true
-  checksum: 10/7e4e5527f41828ffe73ec881c83bcd730418700ac30533f15d89027cb0960317a694aace5202fdcb417347dd7d0495ddf3622e4bc05aaf3ff5ffb8503f04834b
+  checksum: 10/6a83c80b175abfc0fe92084a75600f38dd198775a29e4e3ee6c5954471df9b90a4630a176ad676052ea97b3c1969360ed37f4c839dd986076e01ad2d93d6cb70
   languageName: node
   linkType: hard
 
@@ -1249,10 +1249,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.7.1, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.4.0, @noble/hashes@npm:^1.5.0, @noble/hashes@npm:~1.7.1":
+"@noble/hashes@npm:1.7.1":
   version: 1.7.1
   resolution: "@noble/hashes@npm:1.7.1"
   checksum: 10/ca3120da0c3e7881d6a481e9667465cc9ebbee1329124fb0de442e56d63fef9870f8cc96f264ebdb18096e0e36cebc0e6e979a872d545deb0a6fed9353f17e05
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.4.0, @noble/hashes@npm:^1.5.0, @noble/hashes@npm:~1.7.1":
+  version: 1.7.2
+  resolution: "@noble/hashes@npm:1.7.2"
+  checksum: 10/b5af9e4b91543dcc46a811b5b2c57bfdeb41728361979a19d6110a743e2cb0459872553f68d3a46326d21959964db2776b8c8b4db85ac1d9f63ebcaddf7d59b6
   languageName: node
   linkType: hard
 
@@ -1336,10 +1343,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.1":
-  version: 0.2.2
-  resolution: "@pkgr/core@npm:0.2.2"
-  checksum: 10/7eea03fb7b650f18cbe49e72844de81402476c6f62090ecaba414db14863bee4bcf596cfef334dc882901e5abcb2c82dab7e64010690a8eb7cf01755db357e49
+"@pkgr/core@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@pkgr/core@npm:0.2.3"
+  checksum: 10/38c9435ebc14f6a00cdf45f0ca0c07e652d22949687c9cf709b86caa98054ad5403f2463d5f2407713754f7337b372acda14e537d3a9397f2da78237d4e69841
   languageName: node
   linkType: hard
 
@@ -1352,26 +1359,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@privy-io/public-api@npm:2.21.0, @privy-io/public-api@npm:^2.18.5":
-  version: 2.21.0
-  resolution: "@privy-io/public-api@npm:2.21.0"
+"@privy-io/public-api@npm:2.21.2, @privy-io/public-api@npm:^2.18.5":
+  version: 2.21.2
+  resolution: "@privy-io/public-api@npm:2.21.2"
   dependencies:
     "@privy-io/api-base": "npm:1.4.5"
     bs58: "npm:^5.0.0"
     libphonenumber-js: "npm:^1.10.31"
     viem: "npm:^2"
     zod: "npm:^3.22.4"
-  checksum: 10/4a4edf967401cb329106881e49ae627f4cf6d43ba4e41c95ec438dfe0c7d1e6c4184586d4eb7edf0e928644fa58272afc9f1b3dbe3e1accbe0ac12d152c9e124
+  checksum: 10/3e05987345c89f6a65fc6c77582632faf152e760d0442545be40518ffa902b2fd8212643c7c8b7b10130886229572c31fdce9c5b881cabac122a15c09d559f1a
   languageName: node
   linkType: hard
 
 "@privy-io/server-auth@npm:^1.18.4":
-  version: 1.20.0
-  resolution: "@privy-io/server-auth@npm:1.20.0"
+  version: 1.20.2
+  resolution: "@privy-io/server-auth@npm:1.20.2"
   dependencies:
     "@noble/curves": "npm:^1.6.0"
     "@noble/hashes": "npm:^1.5.0"
-    "@privy-io/public-api": "npm:2.21.0"
+    "@privy-io/public-api": "npm:2.21.2"
     "@solana/web3.js": "npm:^1.95.8"
     canonicalize: "npm:^2.0.0"
     dotenv: "npm:^16.0.3"
@@ -1386,7 +1393,7 @@ __metadata:
   peerDependenciesMeta:
     viem:
       optional: true
-  checksum: 10/c22d87124cf91587b0f7b4f84606050a576b20fd06014ee86a98066f2702967ae81e10c118dbe14be56fea96dc6ae2a3a7790745386cbfb8f55434fbdc3beb0b
+  checksum: 10/3873cf3b1042d5baa88e373eba5a9eeab95e21c1d67c1f7ee283f867bf3ebd7c2f2dac0dbf00801d734f8fd93d80d9a1f34b328627664ae2b2b0618b372af9f6
   languageName: node
   linkType: hard
 
@@ -1735,11 +1742,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:^22.10.5, @types/node@npm:^22.13.0, @types/node@npm:^22.7.5":
-  version: 22.14.0
-  resolution: "@types/node@npm:22.14.0"
+  version: 22.14.1
+  resolution: "@types/node@npm:22.14.1"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10/d0669a8a37a18532c886ccfa51eb3fe1e46088deb4d3d27ebcd5d7d68bd6343ad1c7a3fcb85164780a57629359c33a6c917ecff748ea232bceac7692acc96537
+  checksum: 10/561b1ad98ef5176d6da856ffbbe494f16655149f6a7d561de0423c8784910c81267d7d6459f59d68a97b3cbae9b5996b3b5dfe64f4de3de2239d295dcf4a4dcc
   languageName: node
   linkType: hard
 
@@ -1807,15 +1814,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.29.1"
+"@typescript-eslint/eslint-plugin@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.30.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.29.1"
-    "@typescript-eslint/type-utils": "npm:8.29.1"
-    "@typescript-eslint/utils": "npm:8.29.1"
-    "@typescript-eslint/visitor-keys": "npm:8.29.1"
+    "@typescript-eslint/scope-manager": "npm:8.30.1"
+    "@typescript-eslint/type-utils": "npm:8.30.1"
+    "@typescript-eslint/utils": "npm:8.30.1"
+    "@typescript-eslint/visitor-keys": "npm:8.30.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -1824,64 +1831,64 @@ __metadata:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/0568894f0ea50e67622605eb347d4e26a41571ad06234478ac695a097e9b3ff6252d6d60034853d7a6b8ec644b5c1d354be21075d691173dd7f2fbecb1102674
+  checksum: 10/769b0365c1eda5d15ecb24cd297ca60d264001d46e14f42fae30f6f519610414726885a8d5cf57ef5a01484f92166104a74fb2ca2fd2af28f11cab149b6de591
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/parser@npm:8.29.1"
+"@typescript-eslint/parser@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/parser@npm:8.30.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.29.1"
-    "@typescript-eslint/types": "npm:8.29.1"
-    "@typescript-eslint/typescript-estree": "npm:8.29.1"
-    "@typescript-eslint/visitor-keys": "npm:8.29.1"
+    "@typescript-eslint/scope-manager": "npm:8.30.1"
+    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/typescript-estree": "npm:8.30.1"
+    "@typescript-eslint/visitor-keys": "npm:8.30.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/effb4cc24e375e4229e711b3ea8611a205bf81964cb487f518dd4a7d6cecde7324201ce4e2c3cd420e0ce7649899294307da2cd77f145af4efef3a0292189f20
+  checksum: 10/ffff7bfa7e6b0233feb2d2c9bc27e0fd16faa50a00e9853efcc59de312420ef5a54b94833e80727bc5c966c1b211d70601c2337e33cc5610fa2f28d858642f5b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.29.1"
+"@typescript-eslint/scope-manager@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.30.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.29.1"
-    "@typescript-eslint/visitor-keys": "npm:8.29.1"
-  checksum: 10/33a02f490b53436729f5ca2e6e0c5b8db72adb455274e5de43bdaada21033e7941aed1d92653321991e186af77f7794dc0ac35d2fce891cdf65a6d3fb192249e
+    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/visitor-keys": "npm:8.30.1"
+  checksum: 10/ecae69888a06126d57f3ac2db9935199b708406e8cd84e0918dd8302f31771145d62b52bf3c454be43c5aa4f93685d3f8c15b118d0de1c0323e02113c127aa66
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/type-utils@npm:8.29.1"
+"@typescript-eslint/type-utils@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/type-utils@npm:8.30.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.29.1"
-    "@typescript-eslint/utils": "npm:8.29.1"
+    "@typescript-eslint/typescript-estree": "npm:8.30.1"
+    "@typescript-eslint/utils": "npm:8.30.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/3774d6fb32c058b3fa607480e5603fdd2919e07d8babbc00aa703f31c6fd6f7fbc25c25ff246e7e6ac6b77ad0e0b66838a7136aebc31503a58fbe509f68ab2f4
+  checksum: 10/c7a285bae7806a1e4aa9840feb727fe47f5de4ef3d68ecd1bbebc593a72ec08df17953098d71dc83a6936a42d5a44bcd4a49e6f067ec0947293795b0a389498f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/types@npm:8.29.1"
-  checksum: 10/99ff59e7af3728858af9b7fdc0165955bcf5cd2eefeaafabfbdd7951fbc8ad869cbb7bed7bcbed6c3c50a8661333b33364dc1de0a0c8f3c64d5882339a5d30dd
+"@typescript-eslint/types@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/types@npm:8.30.1"
+  checksum: 10/342ec75ba2c596ffaa93612c6c6afd2b0a05c346bdfa73ac208b49f1969b48a3f739f306431f9a10cf34e99e8585ca924fdde7f9508dd7869142b25f399d6bd6
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.29.1"
+"@typescript-eslint/typescript-estree@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.30.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.29.1"
-    "@typescript-eslint/visitor-keys": "npm:8.29.1"
+    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/visitor-keys": "npm:8.30.1"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -1890,32 +1897,32 @@ __metadata:
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/dded2ebe4c3287443000e3b825e673d0eddb7c48eb2d373c5b7059ea7dbbeba488d7f1de2e42ed7a9299ccff926a65821f2b5594022b49564026ba01c0cc07ab
+  checksum: 10/60c307fbb8ec86d28e4b2237b624427b7aee737bced82e5f94acc84229eae907e7742ccf0c9c0825326b3ccb9f72b14075893d90e06c28f8ce2fd04502c0b410
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/utils@npm:8.29.1"
+"@typescript-eslint/utils@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/utils@npm:8.30.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.29.1"
-    "@typescript-eslint/types": "npm:8.29.1"
-    "@typescript-eslint/typescript-estree": "npm:8.29.1"
+    "@typescript-eslint/scope-manager": "npm:8.30.1"
+    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/typescript-estree": "npm:8.30.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/1d2c85c97a39e063fe490c0cdb6513716e4735bda0bc937475b44d9224074a5070f888dfed1e75f4a91c8f4d825b44fce90b685e07bda391dfeb2553b9b39a5a
+  checksum: 10/97d27d2f0bce6f60a1857d511dba401f076766477a2896405aca52e860f9c5460111299f6e17642e18e578be1dbf850a0b1202ba61aa65d6a52646429ff9c99c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.29.1":
-  version: 8.29.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.29.1"
+"@typescript-eslint/visitor-keys@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.30.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.29.1"
+    "@typescript-eslint/types": "npm:8.30.1"
     eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10/788290c369c13403692d857e0a464b5c2223e1fef28c717b7dbc61140d33697ce43c7d1a7cb7ac585f2012fc702ce2ec489363d34bf566303d3c48fa494803c5
+  checksum: 10/0c08169123ebca4ab04464486a7f41093ba77e75fb088e2c8af9f36bb4c0f785d4e82940f6b62e47457d4758fa57a53423db4226250d6eb284e75a3f96f03f2b
   languageName: node
   linkType: hard
 
@@ -4361,8 +4368,8 @@ __metadata:
   linkType: hard
 
 "openai@npm:^4.77.0, openai@npm:latest":
-  version: 4.93.0
-  resolution: "openai@npm:4.93.0"
+  version: 4.94.0
+  resolution: "openai@npm:4.94.0"
   dependencies:
     "@types/node": "npm:^18.11.18"
     "@types/node-fetch": "npm:^2.6.4"
@@ -4381,7 +4388,7 @@ __metadata:
       optional: true
   bin:
     openai: bin/cli
-  checksum: 10/3135d282ae31294eb78d177a92547497b963d4ee4eb5de75c5ecfa3e0203437d67ff8da7fb9b337ecff1fd19f75f0477e551ed943097fd23b07cbc9d07d77171
+  checksum: 10/0528aadf2faed9069e0f9249701438f8dff1fee821eb5d294b4a16ec6a89c2ea2bab74094656f508bd1f235f30b7b379e08de4aec247ec90322d817aad86e036
   languageName: node
   linkType: hard
 
@@ -5069,12 +5076,12 @@ __metadata:
   linkType: hard
 
 "synckit@npm:^0.11.0":
-  version: 0.11.3
-  resolution: "synckit@npm:0.11.3"
+  version: 0.11.4
+  resolution: "synckit@npm:0.11.4"
   dependencies:
-    "@pkgr/core": "npm:^0.2.1"
+    "@pkgr/core": "npm:^0.2.3"
     tslib: "npm:^2.8.1"
-  checksum: 10/041ebcf2a36e2e121f5d52c2d48a3125a6ed0f9185501d42ff802060563d0a7555be77f466b1d706f4b85054a329d1acd13ccbc37a63825aa022e68a9551535d
+  checksum: 10/37c9fc5af9f06379d263c514e477000074d8af9ef9d3a63354b31dcce39bbf778a67accc2c66c52a13d6fd3871a7fbd36120f713a59edb6fa16358616f3a260f
   languageName: node
   linkType: hard
 
@@ -5239,16 +5246,16 @@ __metadata:
   linkType: hard
 
 "typescript-eslint@npm:^8.22.0":
-  version: 8.29.1
-  resolution: "typescript-eslint@npm:8.29.1"
+  version: 8.30.1
+  resolution: "typescript-eslint@npm:8.30.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.29.1"
-    "@typescript-eslint/parser": "npm:8.29.1"
-    "@typescript-eslint/utils": "npm:8.29.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.30.1"
+    "@typescript-eslint/parser": "npm:8.30.1"
+    "@typescript-eslint/utils": "npm:8.30.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10/0073f809d04586ca09a482ac1becfdc16bc76c8a1828954de1886e0a9f3a75350fd7d65cc5f482eb1524f721dd71457496fee1c59c07de1f7f29e135db005252
+  checksum: 10/aaa4d90abbd7631569d0d45af77fd12cd53aa3bb4e11b8f276cf4cf786ecc14b1fe99e48592f31188386bb021a31fa89b976c69bdcdd0a46dedb98744e7958f2
   languageName: node
   linkType: hard
 
@@ -5393,8 +5400,8 @@ __metadata:
   linkType: hard
 
 "viem@npm:^2, viem@npm:^2.21.26, viem@npm:^2.22.16, viem@npm:^2.22.17":
-  version: 2.26.3
-  resolution: "viem@npm:2.26.3"
+  version: 2.26.5
+  resolution: "viem@npm:2.26.5"
   dependencies:
     "@noble/curves": "npm:1.8.1"
     "@noble/hashes": "npm:1.7.1"
@@ -5409,7 +5416,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/20ec6f998c225f5af29930b90ad3a62a6057b522ad834954e4ba687713d643bf5252af74bed1f26ae12a737e7261fb9b5f6a89058c6747a66917991a2b6636d6
+  checksum: 10/29a112e8fc2dea1eec80350727bf0f503c65ea761f317ab4b25f9fd1ba42c6c0ef3798f13714be5aa9a30860ff997b2be3ad4539776a4f5d219cbc9a71b8d4a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Update XMTP client initialization to use new API format in `@xmtp/node-sdk` v2.0.0
* Updates all example projects and documentation to use `@xmtp/node-sdk` v2.0.0, which introduces a new client initialization pattern where encryption keys are passed via an options object
* Refactors the `logAgentDetails` function in [helpers/utils.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/108/files#diff-253d326c009147a6c4c0327e9e16f4d7fee7b150c2dbadad50f41f8b530b47cd) to accept a `Client` object instead of individual parameters
* Moves initialization of signers and encryption keys from global scope into main functions across multiple example projects
* Fixes a typo in web inbox URL in [.cursor/rules/xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/108/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20)
* Updates GitHub Actions workflows to use specific commit SHAs and full git history

#### 📍Where to Start
Start with the changes to the client initialization pattern in [examples/xmtp-gm/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/108/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9), which demonstrates the core API changes in a simple example.

----

_[Macroscope](https://app.macroscope.com) summarized 00fe52e._