### PR TITLE
Upgrade node 2.0.1 + content types

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -6,7 +6,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
 1.  Use modern TypeScript patterns and ESM modules. All examples should be structured as ES modules with `import` statements rather than CommonJS `require()`.
 
-2.  Use the XMTP node-sdk version "2.0.0" or newer, which offers enhanced functionality including group conversations.
+2.  Use the XMTP node-sdk version "2.0.1" or newer, which offers enhanced functionality including group conversations.
 
 3.  Only import from @xmtp/node-sdk for XMTP functionality. Do not import from any other XMTP-related packages or URLs. Specifically:
 
@@ -256,7 +256,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```json
     {
       "dependencies": {
-        "@xmtp/node-sdk": "2.0.0"
+        "@xmtp/node-sdk": "2.0.1"
         /* other dependencies */
       }
     }
@@ -303,7 +303,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
         "start": "tsx index.ts"
       },
       "dependencies": {
-        "@xmtp/node-sdk": "2.0.0"
+        "@xmtp/node-sdk": "2.0.1"
       },
       "devDependencies": {
         "tsx": "^4.19.2",

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -933,7 +933,7 @@ if (!fs.existsSync(dbPath)) {
 
 ### Web inbox
 
-Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
+Interact with the XMTP network using [xmtp.chat](mdc:https:/xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -11,7 +11,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
 1.  Use modern TypeScript patterns and ESM modules. All examples should be structured as ES modules with `import` statements rather than CommonJS `require()`.
 
-2.  Use the XMTP node-sdk version "2.0.0" or newer, which offers enhanced functionality including group conversations.
+2.  Use the XMTP node-sdk version "2.0.1" or newer, which offers enhanced functionality including group conversations.
 
 3.  Only import from @xmtp/node-sdk for XMTP functionality. Do not import from any other XMTP-related packages or URLs. Specifically:
 
@@ -261,7 +261,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```json
     {
       "dependencies": {
-        "@xmtp/node-sdk": "2.0.0"
+        "@xmtp/node-sdk": "2.0.1"
         /* other dependencies */
       }
     }
@@ -308,7 +308,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
         "start": "tsx index.ts"
       },
       "dependencies": {
-        "@xmtp/node-sdk": "2.0.0"
+        "@xmtp/node-sdk": "2.0.1"
       },
       "devDependencies": {
         "tsx": "^4.19.2",
@@ -346,13 +346,12 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
 // Define the address to always add to new groups
 const MEMBER_ADDRESS = "0x7c40611372d354799d138542e77243c284e460b2";
 
-// Initialize client
-const signer = createSigner(WALLET_KEY);
-const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-
 async function main() {
+  // Initialize client
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
   const client = await Client.create(signer, {
-    dbEncryptionKey: encryptionKey,
+    dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
   });
 
@@ -934,7 +933,7 @@ if (!fs.existsSync(dbPath)) {
 
 ### Web inbox
 
-Interact with the XMTP netwoxmtp.chat](https://xmtp.chat), the official web inbox for developers.
+Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
 ### Work in local network
 

--- a/examples/xmtp-attachment-content-type/index.ts
+++ b/examples/xmtp-attachment-content-type/index.ts
@@ -100,12 +100,12 @@ async function main() {
     if (message.contentType.sameAs(ContentTypeRemoteAttachment)) {
       console.log("Received an attachment!");
 
-      const attachment = (await RemoteAttachmentCodec.load(
+      const attachment = await RemoteAttachmentCodec.load(
         message.content as RemoteAttachment,
         client,
-      )) as Attachment;
+      );
 
-      const filename = attachment.filename || "unnamed";
+      const filename = (attachment as Attachment).filename || "unnamed";
       await conversation.send(`I received your attachment "${filename}"!`);
 
       continue;

--- a/examples/xmtp-attachment-content-type/package.json
+++ b/examples/xmtp-attachment-content-type/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/content-type-remote-attachment": "^2.0.1",
+    "@xmtp/content-type-remote-attachment": "^2.0.2",
     "@xmtp/node-sdk": "2.0.0",
     "axios": "^1.8.4",
     "form-data": "^4.0.2"

--- a/examples/xmtp-attachment-content-type/package.json
+++ b/examples/xmtp-attachment-content-type/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-remote-attachment": "^2.0.2",
-    "@xmtp/node-sdk": "2.0.0",
+    "@xmtp/node-sdk": "2.0.1",
     "axios": "^1.8.4",
     "form-data": "^4.0.2"
   },

--- a/examples/xmtp-attachment-content-type/package.json
+++ b/examples/xmtp-attachment-content-type/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-remote-attachment": "^2.0.2",
-    "@xmtp/node-sdk": "2.0.1",
+    "@xmtp/node-sdk": "*",
     "axios": "^1.8.4",
     "form-data": "^4.0.2"
   },

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -269,7 +269,9 @@ async function handleMessage(message: DecodedMessage, client: Client) {
       return;
     }
 
-    console.log(`Received message from ${senderAddress}: ${message.content}`);
+    console.log(
+      `Received message from ${senderAddress}: ${message.content as string}`,
+    );
 
     const { agent, config } = await initializeAgent(senderAddress);
     const response = await processMessage(

--- a/examples/xmtp-coinbase-agentkit/package.json
+++ b/examples/xmtp-coinbase-agentkit/package.json
@@ -16,7 +16,7 @@
     "@langchain/core": "^0.3.19",
     "@langchain/langgraph": "^0.2.21",
     "@langchain/openai": "^0.3.14",
-    "@xmtp/node-sdk": "2.0.1"
+    "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-coinbase-agentkit/package.json
+++ b/examples/xmtp-coinbase-agentkit/package.json
@@ -16,7 +16,7 @@
     "@langchain/core": "^0.3.19",
     "@langchain/langgraph": "^0.2.21",
     "@langchain/openai": "^0.3.14",
-    "@xmtp/node-sdk": "2.0.0"
+    "@xmtp/node-sdk": "2.0.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-gaia/package.json
+++ b/examples/xmtp-gaia/package.json
@@ -11,7 +11,7 @@
     "start": "tsx  index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.0",
+    "@xmtp/node-sdk": "2.0.1",
     "openai": "latest"
   },
   "devDependencies": {

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -1,6 +1,6 @@
 import { createSigner, getEncryptionKeyFromHex } from "@helpers/client";
 import { logAgentDetails, validateEnvironment } from "@helpers/utils";
-import { Client, IdentifierKind, type XmtpEnv } from "@xmtp/node-sdk";
+import { Client, type XmtpEnv } from "@xmtp/node-sdk";
 
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
@@ -51,15 +51,6 @@ async function main() {
     const addressFromInboxId = inboxState[0].identifiers[0].identifier;
     console.log(`Sending "gm" response to ${addressFromInboxId}...`);
     await conversation.send("gm");
-
-    const canMessage = await client.canMessage([
-      {
-        identifier: addressFromInboxId,
-        identifierKind: IdentifierKind.Ethereum,
-      },
-    ]);
-
-    console.log(canMessage);
 
     console.log("Waiting for messages...");
   }

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -1,6 +1,6 @@
 import { createSigner, getEncryptionKeyFromHex } from "@helpers/client";
 import { logAgentDetails, validateEnvironment } from "@helpers/utils";
-import { Client, type XmtpEnv } from "@xmtp/node-sdk";
+import { Client, IdentifierKind, type XmtpEnv } from "@xmtp/node-sdk";
 
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
@@ -51,6 +51,15 @@ async function main() {
     const addressFromInboxId = inboxState[0].identifiers[0].identifier;
     console.log(`Sending "gm" response to ${addressFromInboxId}...`);
     await conversation.send("gm");
+
+    const canMessage = await client.canMessage([
+      {
+        identifier: addressFromInboxId,
+        identifierKind: IdentifierKind.Ethereum,
+      },
+    ]);
+
+    console.log(canMessage);
 
     console.log("Waiting for messages...");
   }

--- a/examples/xmtp-gm/package.json
+++ b/examples/xmtp-gm/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.0"
+    "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-gpt/package.json
+++ b/examples/xmtp-gpt/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.0",
+    "@xmtp/node-sdk": "2.0.1",
     "openai": "latest"
   },
   "devDependencies": {

--- a/examples/xmtp-gpt/package.json
+++ b/examples/xmtp-gpt/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.1",
+    "@xmtp/node-sdk": "*",
     "openai": "latest"
   },
   "devDependencies": {

--- a/examples/xmtp-multiple-clients/index.ts
+++ b/examples/xmtp-multiple-clients/index.ts
@@ -55,7 +55,7 @@ async function gmMessageHandler(
     console.log(
       `[${worker.name}] Received message from ${addressFromInboxId}:`,
     );
-    console.log(`  Content: ${message.content}`);
+    console.log(`Content: ${message.content as string}`);
 
     // Send "gm" response
     console.log(

--- a/examples/xmtp-multiple-clients/package.json
+++ b/examples/xmtp-multiple-clients/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.0"
+    "@xmtp/node-sdk": "2.0.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-multiple-clients/package.json
+++ b/examples/xmtp-multiple-clients/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.1"
+    "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-nft-gated-group/package.json
+++ b/examples/xmtp-nft-gated-group/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.1",
+    "@xmtp/node-sdk": "*",
     "alchemy-sdk": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/xmtp-nft-gated-group/package.json
+++ b/examples/xmtp-nft-gated-group/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.0",
+    "@xmtp/node-sdk": "2.0.1",
     "alchemy-sdk": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/xmtp-smart-wallet/package.json
+++ b/examples/xmtp-smart-wallet/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/coinbase-sdk": "latest",
-    "@xmtp/node-sdk": "2.0.0"
+    "@xmtp/node-sdk": "2.0.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-smart-wallet/package.json
+++ b/examples/xmtp-smart-wallet/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/coinbase-sdk": "latest",
-    "@xmtp/node-sdk": "2.0.1"
+    "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-stream-restart/package.json
+++ b/examples/xmtp-stream-restart/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.0"
+    "@xmtp/node-sdk": "2.0.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-stream-restart/package.json
+++ b/examples/xmtp-stream-restart/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.1"
+    "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-transaction-content-type/index.ts
+++ b/examples/xmtp-transaction-content-type/index.ts
@@ -97,7 +97,7 @@ async function main() {
           agentAddress,
           amountInDecimals,
         );
-
+        console.log("Replied with wallet sendcall");
         await conversation.send(walletSendCalls, ContentTypeWalletSendCalls);
       } else {
         await conversation.send(

--- a/examples/xmtp-transaction-content-type/package.json
+++ b/examples/xmtp-transaction-content-type/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@xmtp/content-type-transaction-reference": "^2.0.2",
     "@xmtp/content-type-wallet-send-calls": "^1.0.1",
-    "@xmtp/node-sdk": "2.0.0"
+    "@xmtp/node-sdk": "2.0.1"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-transaction-content-type/package.json
+++ b/examples/xmtp-transaction-content-type/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@xmtp/content-type-transaction-reference": "^2.0.2",
     "@xmtp/content-type-wallet-send-calls": "^1.0.1",
-    "@xmtp/node-sdk": "2.0.1"
+    "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/xmtp-transaction-content-type/package.json
+++ b/examples/xmtp-transaction-content-type/package.json
@@ -11,8 +11,8 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/content-type-transaction-reference": "^2.0.1",
-    "@xmtp/content-type-wallet-send-calls": "^1.0.0",
+    "@xmtp/content-type-transaction-reference": "^2.0.2",
+    "@xmtp/content-type-wallet-send-calls": "^1.0.1",
     "@xmtp/node-sdk": "2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.0",
+    "@xmtp/node-sdk": "2.0.1",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,7 +896,7 @@ __metadata:
   resolution: "@examples/xmtp-attachment-content-type@workspace:examples/xmtp-attachment-content-type"
   dependencies:
     "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     axios: "npm:^1.8.4"
     form-data: "npm:^4.0.2"
     tsx: "npm:^4.19.2"
@@ -913,7 +913,7 @@ __metadata:
     "@langchain/core": "npm:^0.3.19"
     "@langchain/langgraph": "npm:^0.2.21"
     "@langchain/openai": "npm:^0.3.14"
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -944,7 +944,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gpt@workspace:examples/xmtp-gpt"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     openai: "npm:latest"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -955,7 +955,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-multiple-clients@workspace:examples/xmtp-multiple-clients"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -965,7 +965,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-nft-gated-group@workspace:examples/xmtp-nft-gated-group"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     alchemy-sdk: "npm:^3.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -977,7 +977,7 @@ __metadata:
   resolution: "@examples/xmtp-smart-wallet@workspace:examples/xmtp-smart-wallet"
   dependencies:
     "@coinbase/coinbase-sdk": "npm:latest"
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -987,7 +987,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-stream-restart@workspace:examples/xmtp-stream-restart"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -999,7 +999,7 @@ __metadata:
   dependencies:
     "@xmtp/content-type-transaction-reference": "npm:^2.0.2"
     "@xmtp/content-type-wallet-send-calls": "npm:^1.0.1"
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:*"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,7 +895,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-attachment-content-type@workspace:examples/xmtp-attachment-content-type"
   dependencies:
-    "@xmtp/content-type-remote-attachment": "npm:^2.0.1"
+    "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
     "@xmtp/node-sdk": "npm:2.0.0"
     axios: "npm:^1.8.4"
     form-data: "npm:^4.0.2"
@@ -997,8 +997,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-transaction-content-type@workspace:examples/xmtp-transaction-content-type"
   dependencies:
-    "@xmtp/content-type-transaction-reference": "npm:^2.0.1"
-    "@xmtp/content-type-wallet-send-calls": "npm:^1.0.0"
+    "@xmtp/content-type-transaction-reference": "npm:^2.0.2"
+    "@xmtp/content-type-wallet-send-calls": "npm:^1.0.1"
     "@xmtp/node-sdk": "npm:2.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -1945,14 +1945,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-remote-attachment@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@xmtp/content-type-remote-attachment@npm:2.0.1"
+"@xmtp/content-type-primitives@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@xmtp/content-type-primitives@npm:2.0.2"
+  dependencies:
+    "@xmtp/proto": "npm:^3.78.0"
+  checksum: 10/9c115c1e792bca5e5e7180ba5494786bd3554265bc0ccdcb26d645689634ae239cefb3996bbbe493a487a2c8c7bf4e85954f4063811f784021afe16e58b1b03b
+  languageName: node
+  linkType: hard
+
+"@xmtp/content-type-remote-attachment@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@xmtp/content-type-remote-attachment@npm:2.0.2"
   dependencies:
     "@noble/secp256k1": "npm:^2.2.3"
-    "@xmtp/content-type-primitives": "npm:^2.0.1"
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/c0e3710f585a1a81cc0fbd7e8d1d71c2ae40a820b01c52bd36b59fed1159cef17ec689ba3cd8e4e83870db23ca119ba9d094656431033b1c8413e5af1bfa44e9
+  checksum: 10/7d4f89b595c42dbd3687edba41efd11cf225267419115f5cf05fa9ef4c02aadf29c9b5605681407063721e0ef421789f6a16d0d2f379416dfb726be83151571e
   languageName: node
   linkType: hard
 
@@ -1965,21 +1974,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-transaction-reference@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@xmtp/content-type-transaction-reference@npm:2.0.1"
+"@xmtp/content-type-transaction-reference@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@xmtp/content-type-transaction-reference@npm:2.0.2"
   dependencies:
-    "@xmtp/content-type-primitives": "npm:^2.0.1"
-  checksum: 10/809fa9e24241e358fe86030b52ba0005555ffc2bfb0520decbbe9057b54b784c92c5bb2ddaffe27ef0b21cec5d8809c74ded2a0ac297f5f6c747af95be6c133d
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+  checksum: 10/37437069fe47812647f856f871d83d95e62a35dd297f30578a3857dc90575284dad56ad3d734eeb1fe3599aa43512c2ae9e492b41404c492bdd70f9e7d03f734
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-wallet-send-calls@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@xmtp/content-type-wallet-send-calls@npm:1.0.0"
+"@xmtp/content-type-wallet-send-calls@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@xmtp/content-type-wallet-send-calls@npm:1.0.1"
   dependencies:
-    "@xmtp/content-type-primitives": "npm:^2.0.1"
-  checksum: 10/8157fe51b8917c12c924cb011faedd0391b6881915a1401de34909379f03559f5b4507c7bd9759671f744ebdea7d43d54ade957b77a6fad95cd99cbb96902a7e
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+  checksum: 10/96ae24f14f6ff86f72ad2b09ed81ec3398947ddce1e6b5c0fe83324b66a83f797ee75976f66a8937cff025e0cc7bfab444547371011c43687f6ba6eae51c3ba2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,7 +896,7 @@ __metadata:
   resolution: "@examples/xmtp-attachment-content-type@workspace:examples/xmtp-attachment-content-type"
   dependencies:
     "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     axios: "npm:^1.8.4"
     form-data: "npm:^4.0.2"
     tsx: "npm:^4.19.2"
@@ -913,7 +913,7 @@ __metadata:
     "@langchain/core": "npm:^0.3.19"
     "@langchain/langgraph": "npm:^0.2.21"
     "@langchain/openai": "npm:^0.3.14"
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -923,7 +923,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gaia@workspace:examples/xmtp-gaia"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     openai: "npm:latest"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -934,7 +934,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gm@workspace:examples/xmtp-gm"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:*"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -944,7 +944,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gpt@workspace:examples/xmtp-gpt"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     openai: "npm:latest"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -955,7 +955,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-multiple-clients@workspace:examples/xmtp-multiple-clients"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -965,7 +965,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-nft-gated-group@workspace:examples/xmtp-nft-gated-group"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     alchemy-sdk: "npm:^3.0.0"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
@@ -977,7 +977,7 @@ __metadata:
   resolution: "@examples/xmtp-smart-wallet@workspace:examples/xmtp-smart-wallet"
   dependencies:
     "@coinbase/coinbase-sdk": "npm:latest"
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -987,7 +987,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-stream-restart@workspace:examples/xmtp-stream-restart"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -999,7 +999,7 @@ __metadata:
   dependencies:
     "@xmtp/content-type-transaction-reference": "npm:^2.0.2"
     "@xmtp/content-type-wallet-send-calls": "npm:^1.0.1"
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.3"
   languageName: unknown
@@ -1926,22 +1926,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-group-updated@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@xmtp/content-type-group-updated@npm:2.0.1"
+"@xmtp/content-type-group-updated@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@xmtp/content-type-group-updated@npm:2.0.2"
   dependencies:
-    "@xmtp/content-type-primitives": "npm:^2.0.1"
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/75d8f30fedf2524335745865c286ef4b240e2c2c9b981d9044ef4d6b09f5c5324f13b448ef8358c4a13d3d0c49fd6a964dab6d94974cf2fcc887ecaefb2e6671
-  languageName: node
-  linkType: hard
-
-"@xmtp/content-type-primitives@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@xmtp/content-type-primitives@npm:2.0.1"
-  dependencies:
-    "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/966d17a2ef9b70452348651e7eb56d858608d4b910343bdc8886bc73693040ea34ce69bac74bd4367404f6cf6f7b6ec7b25a2dd25c507fc35bee1447065ea02d
+  checksum: 10/83aeef5e2bf0f882df9e400898ff6845b763e38d18ce2dda764a22f241c83b7765f0b7e18161a71e770f725da29f2760c48b720ca1b77cbe5abbdc91bfb6c5c8
   languageName: node
   linkType: hard
 
@@ -1965,12 +1956,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-text@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@xmtp/content-type-text@npm:2.0.1"
+"@xmtp/content-type-text@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@xmtp/content-type-text@npm:2.0.2"
   dependencies:
-    "@xmtp/content-type-primitives": "npm:^2.0.1"
-  checksum: 10/7febd12cfbb69a80c434caef4111ccd02d5e9b24eb58fb0f27a35d5f14c61c47e949322b1715a25918ff4d70d0392116ac310a4e2e59f1e23dc2223ca8a141fc
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+  checksum: 10/21905043e8b90845223f8e7a86c43c40881bec401ebf840d4f94ab4050cf6b3e071e2b235d51426e7179e767e6e1a77a2cf2689582629deda7b1dc5ec646b110
   languageName: node
   linkType: hard
 
@@ -1999,16 +1990,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@xmtp/node-sdk@npm:2.0.0"
+"@xmtp/node-sdk@npm:*, @xmtp/node-sdk@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@xmtp/node-sdk@npm:2.0.1"
   dependencies:
-    "@xmtp/content-type-group-updated": "npm:^2.0.1"
-    "@xmtp/content-type-primitives": "npm:^2.0.1"
-    "@xmtp/content-type-text": "npm:^2.0.1"
+    "@xmtp/content-type-group-updated": "npm:^2.0.2"
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+    "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
     "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/c220be1ee441a255896754ebd0030ba528935f82fb7b59cf9ba3de32acc4312354d2a2258a34b2730decbac3ea05bbd0a257799bddb80cbf2b03d5c74934db9d
+  checksum: 10/8eb8ec232f45d1e6f9ebbbee4b068d754ce5a843faf3f91387751bb02155283448bb35ee44eff2483877d8ae684c58d34f76234319ed32e350f96818c90fd427
   languageName: node
   linkType: hard
 
@@ -5603,7 +5594,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:2.0.0"
+    "@xmtp/node-sdk": "npm:2.0.1"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"


### PR DESCRIPTION
### Upgrade XMTP node-sdk to version 2.0.1 and update content type dependencies across documentation and examples
* Updates XMTP `node-sdk` dependency from version 2.0.0 to 2.0.1 in documentation and example projects
* Updates content type dependencies: `@xmtp/content-type-remote-attachment` to ^2.0.2 and `@xmtp/content-type-transaction-reference` to ^2.0.2
* Improves type safety in example code by adding explicit type assertions for message content in logging statements
* Modifies client initialization pattern in [xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/110/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20) by moving it inside the main function
* Removes unnecessary type casting in `RemoteAttachmentCodec.load()` function in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/110/files#diff-679e655f285c5b82ee82cb31084d244b45c1805fae918c42dff5b0730093e5b6)

#### 📍Where to Start
Start with the dependency updates in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/110/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and then review the type safety improvements in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/110/files#diff-679e655f285c5b82ee82cb31084d244b45c1805fae918c42dff5b0730093e5b6)

----

_[Macroscope](https://app.macroscope.com) summarized 5c3ad7b._