### PR TITLE
Update devDependencies to use flexible versions

### DIFF
--- a/examples/xmtp-attachment-content-type/package.json
+++ b/examples/xmtp-attachment-content-type/package.json
@@ -17,8 +17,8 @@
     "form-data": "^4.0.2"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-coinbase-agentkit/package.json
+++ b/examples/xmtp-coinbase-agentkit/package.json
@@ -19,8 +19,8 @@
     "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-gaia/package.json
+++ b/examples/xmtp-gaia/package.json
@@ -11,12 +11,12 @@
     "start": "tsx  index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.1",
+    "@xmtp/node-sdk": "*",
     "openai": "latest"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-gm/package.json
+++ b/examples/xmtp-gm/package.json
@@ -14,8 +14,8 @@
     "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-gpt/package.json
+++ b/examples/xmtp-gpt/package.json
@@ -15,8 +15,8 @@
     "openai": "latest"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-multiple-clients/package.json
+++ b/examples/xmtp-multiple-clients/package.json
@@ -14,8 +14,8 @@
     "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-nft-gated-group/package.json
+++ b/examples/xmtp-nft-gated-group/package.json
@@ -15,8 +15,8 @@
     "alchemy-sdk": "^3.0.0"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-smart-wallet/package.json
+++ b/examples/xmtp-smart-wallet/package.json
@@ -11,12 +11,12 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@coinbase/coinbase-sdk": "latest",
+    "@coinbase/coinbase-sdk": "0.22.0",
     "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-stream-restart/package.json
+++ b/examples/xmtp-stream-restart/package.json
@@ -14,8 +14,8 @@
     "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/examples/xmtp-transaction-content-type/package.json
+++ b/examples/xmtp-transaction-content-type/package.json
@@ -16,8 +16,8 @@
     "@xmtp/node-sdk": "*"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "*",
+    "typescript": "*"
   },
   "packageManager": "yarn@4.6.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.0.1",
+    "@xmtp/node-sdk": "2.0.2",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,6 +177,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@coinbase/coinbase-sdk@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@coinbase/coinbase-sdk@npm:0.22.0"
+  dependencies:
+    "@scure/bip32": "npm:^1.4.0"
+    abitype: "npm:^1.0.6"
+    axios: "npm:^1.6.8"
+    axios-mock-adapter: "npm:^1.22.0"
+    axios-retry: "npm:^4.4.1"
+    bip32: "npm:^4.0.0"
+    bip39: "npm:^3.1.0"
+    decimal.js: "npm:^10.4.3"
+    dotenv: "npm:^16.4.5"
+    ed2curve: "npm:^0.3.0"
+    ethers: "npm:^6.12.1"
+    jose: "npm:^5.10.0"
+    secp256k1: "npm:^5.0.0"
+    viem: "npm:^2.21.26"
+  checksum: 10/47f2f24d83421f95ee16eb6d6132e7082ff4b1e87be148065a6a97057b06c1f3d67fe0e0cf6839e2d6673f28e2ce6ccab249673c4f3aa0b8fe3aeb9240a1c3d8
+  languageName: node
+  linkType: hard
+
 "@coinbase/coinbase-sdk@npm:^0.20.0":
   version: 0.20.0
   resolution: "@coinbase/coinbase-sdk@npm:0.20.0"
@@ -196,28 +218,6 @@ __metadata:
     secp256k1: "npm:^5.0.0"
     viem: "npm:^2.21.26"
   checksum: 10/c6a4b220508c84dfc40b0ae6f1549ef8ed1afc50a596ba39c96815f9baf98802b7868d9d6d815e3e95a8ef78e5e280e77bc89345334a6e7fd6a8ee4f8593dde2
-  languageName: node
-  linkType: hard
-
-"@coinbase/coinbase-sdk@npm:latest":
-  version: 0.22.0
-  resolution: "@coinbase/coinbase-sdk@npm:0.22.0"
-  dependencies:
-    "@scure/bip32": "npm:^1.4.0"
-    abitype: "npm:^1.0.6"
-    axios: "npm:^1.6.8"
-    axios-mock-adapter: "npm:^1.22.0"
-    axios-retry: "npm:^4.4.1"
-    bip32: "npm:^4.0.0"
-    bip39: "npm:^3.1.0"
-    decimal.js: "npm:^10.4.3"
-    dotenv: "npm:^16.4.5"
-    ed2curve: "npm:^0.3.0"
-    ethers: "npm:^6.12.1"
-    jose: "npm:^5.10.0"
-    secp256k1: "npm:^5.0.0"
-    viem: "npm:^2.21.26"
-  checksum: 10/47f2f24d83421f95ee16eb6d6132e7082ff4b1e87be148065a6a97057b06c1f3d67fe0e0cf6839e2d6673f28e2ce6ccab249673c4f3aa0b8fe3aeb9240a1c3d8
   languageName: node
   linkType: hard
 
@@ -899,8 +899,8 @@ __metadata:
     "@xmtp/node-sdk": "npm:*"
     axios: "npm:^1.8.4"
     form-data: "npm:^4.0.2"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -914,8 +914,8 @@ __metadata:
     "@langchain/langgraph": "npm:^0.2.21"
     "@langchain/openai": "npm:^0.3.14"
     "@xmtp/node-sdk": "npm:*"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -923,10 +923,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-gaia@workspace:examples/xmtp-gaia"
   dependencies:
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:2.0.2"
     openai: "npm:latest"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -935,8 +935,8 @@ __metadata:
   resolution: "@examples/xmtp-gm@workspace:examples/xmtp-gm"
   dependencies:
     "@xmtp/node-sdk": "npm:*"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -946,8 +946,8 @@ __metadata:
   dependencies:
     "@xmtp/node-sdk": "npm:*"
     openai: "npm:latest"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -956,8 +956,8 @@ __metadata:
   resolution: "@examples/xmtp-multiple-clients@workspace:examples/xmtp-multiple-clients"
   dependencies:
     "@xmtp/node-sdk": "npm:*"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -967,8 +967,8 @@ __metadata:
   dependencies:
     "@xmtp/node-sdk": "npm:*"
     alchemy-sdk: "npm:^3.0.0"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -976,10 +976,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-smart-wallet@workspace:examples/xmtp-smart-wallet"
   dependencies:
-    "@coinbase/coinbase-sdk": "npm:latest"
+    "@coinbase/coinbase-sdk": "npm:0.22.0"
     "@xmtp/node-sdk": "npm:*"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -988,8 +988,8 @@ __metadata:
   resolution: "@examples/xmtp-stream-restart@workspace:examples/xmtp-stream-restart"
   dependencies:
     "@xmtp/node-sdk": "npm:*"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -1000,8 +1000,8 @@ __metadata:
     "@xmtp/content-type-transaction-reference": "npm:^2.0.2"
     "@xmtp/content-type-wallet-send-calls": "npm:^1.0.1"
     "@xmtp/node-sdk": "npm:*"
-    tsx: "npm:^4.19.2"
-    typescript: "npm:^5.7.3"
+    tsx: "npm:*"
+    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -1990,7 +1990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:*, @xmtp/node-sdk@npm:2.0.1":
+"@xmtp/node-sdk@npm:*":
   version: 2.0.1
   resolution: "@xmtp/node-sdk@npm:2.0.1"
   dependencies:
@@ -2000,6 +2000,19 @@ __metadata:
     "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
     "@xmtp/proto": "npm:^3.78.0"
   checksum: 10/8eb8ec232f45d1e6f9ebbbee4b068d754ce5a843faf3f91387751bb02155283448bb35ee44eff2483877d8ae684c58d34f76234319ed32e350f96818c90fd427
+  languageName: node
+  linkType: hard
+
+"@xmtp/node-sdk@npm:2.0.2":
+  version: 2.0.2
+  resolution: "@xmtp/node-sdk@npm:2.0.2"
+  dependencies:
+    "@xmtp/content-type-group-updated": "npm:^2.0.2"
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+    "@xmtp/content-type-text": "npm:^2.0.2"
+    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
+    "@xmtp/proto": "npm:^3.78.0"
+  checksum: 10/c75bb2a4f218baed1145a2546b3f2c552c8ea5ec866f806bea192b59854172bb44f75568eafdc3e19ef9a949514243fca68fdb38bd06000fe88021e3e1f8912f
   languageName: node
   linkType: hard
 
@@ -5176,7 +5189,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.19.2":
+"tsx@npm:*, tsx@npm:^4.19.2":
   version: 4.19.3
   resolution: "tsx@npm:4.19.3"
   dependencies:
@@ -5259,7 +5272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.7.2, typescript@npm:^5.7.3":
+"typescript@npm:*, typescript@npm:^5.7.2, typescript@npm:^5.7.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -5269,7 +5282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A*#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
@@ -5594,7 +5607,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:2.0.1"
+    "@xmtp/node-sdk": "npm:2.0.2"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"


### PR DESCRIPTION
### Update development dependencies to use flexible versioning across example projects
* Updates `tsx` and `typescript` dependencies to use wildcard (`*`) versioning in 10 example project `package.json` files
* Changes `@xmtp/node-sdk` dependency to wildcard (`*`) version in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/113/files#diff-bf755da31fcc99af38cf36a778710ba0e33568a0fc829abcf975989dee421dd8)
* Updates `@coinbase/coinbase-sdk` from `latest` to specific version `0.22.0` in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/113/files#diff-30e3b61c4563b8e36757ece3ee27e32b011432579242b43acf545f611eab8d8a)
* Updates root project `@xmtp/node-sdk` dependency from `2.0.1` to `2.0.2` in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/113/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
* Updates [yarn.lock](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/113/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect all dependency changes

#### 📍Where to Start
Start by reviewing the root [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/113/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) file to understand the core dependency updates, then examine the changes in example project package files starting with [xmtp-gaia/package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/113/files#diff-bf755da31fcc99af38cf36a778710ba0e33568a0fc829abcf975989dee421dd8) which has the most dependency updates.

----

_[Macroscope](https://app.macroscope.com) summarized 27e0cf1._