### PR TITLE
Remove unnecessary devDependencies from examples

### DIFF
--- a/.cursor/rules/monorepo-guidelines.md
+++ b/.cursor/rules/monorepo-guidelines.md
@@ -29,10 +29,7 @@ When creating new agent examples in this monorepo, follow these guidelines for c
     "@xmtp/node-sdk": "*" // Inherit the version from the root package.json
     /* other dependencies */
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
+
   "engines": {
     "node": ">=20"
   }

--- a/.cursor/rules/monorepo-guidelines.mdc
+++ b/.cursor/rules/monorepo-guidelines.mdc
@@ -34,10 +34,7 @@ When creating new agent examples in this monorepo, follow these guidelines for c
     "@xmtp/node-sdk": "*" // Inherit the version from the root package.json
     /* other dependencies */
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
+  
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-attachment-content-type/package.json
+++ b/examples/xmtp-attachment-content-type/package.json
@@ -16,10 +16,6 @@
     "axios": "^1.8.4",
     "form-data": "^4.0.2"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-coinbase-agentkit/package.json
+++ b/examples/xmtp-coinbase-agentkit/package.json
@@ -18,10 +18,6 @@
     "@langchain/openai": "^0.3.14",
     "@xmtp/node-sdk": "*"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-gaia/package.json
+++ b/examples/xmtp-gaia/package.json
@@ -14,10 +14,6 @@
     "@xmtp/node-sdk": "*",
     "openai": "latest"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-gm/package.json
+++ b/examples/xmtp-gm/package.json
@@ -13,10 +13,6 @@
   "dependencies": {
     "@xmtp/node-sdk": "*"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-gpt/package.json
+++ b/examples/xmtp-gpt/package.json
@@ -14,10 +14,6 @@
     "@xmtp/node-sdk": "*",
     "openai": "latest"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-multiple-clients/package.json
+++ b/examples/xmtp-multiple-clients/package.json
@@ -13,10 +13,6 @@
   "dependencies": {
     "@xmtp/node-sdk": "*"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-nft-gated-group/package.json
+++ b/examples/xmtp-nft-gated-group/package.json
@@ -14,10 +14,6 @@
     "@xmtp/node-sdk": "*",
     "alchemy-sdk": "^3.0.0"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-smart-wallet/package.json
+++ b/examples/xmtp-smart-wallet/package.json
@@ -14,10 +14,6 @@
     "@coinbase/coinbase-sdk": "^0.22.0",
     "@xmtp/node-sdk": "*"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-stream-restart/package.json
+++ b/examples/xmtp-stream-restart/package.json
@@ -13,10 +13,6 @@
   "dependencies": {
     "@xmtp/node-sdk": "*"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/examples/xmtp-transaction-content-type/package.json
+++ b/examples/xmtp-transaction-content-type/package.json
@@ -15,10 +15,6 @@
     "@xmtp/content-type-wallet-send-calls": "^1.0.1",
     "@xmtp/node-sdk": "*"
   },
-  "devDependencies": {
-    "tsx": "*",
-    "typescript": "*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,8 +935,6 @@ __metadata:
   resolution: "@examples/xmtp-gm@workspace:examples/xmtp-gm"
   dependencies:
     "@xmtp/node-sdk": "npm:*"
-    tsx: "npm:*"
-    typescript: "npm:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Remove `tsx` and `typescript` devDependencies from example packages to rely on monorepo root dependencies
* Removes `devDependencies` section containing `tsx` and `typescript` from multiple example package.json files in the monorepo, centralizing these dependencies at the root level
* Updates monorepo guidelines documentation in [monorepo-guidelines.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/118/files#diff-9274d21b31786b92badb27529fe55af4d42e1c898020e547e1c5b60c8ad56899) and [monorepo-guidelines.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/118/files#diff-a32590ae7d1766c8a332777c4d9d2ab96a69f6a4b40af059fc23b876b6e4cfcc) to reflect the removal of these dependencies from example configurations

#### 📍Where to Start
Start with the monorepo guidelines documentation at [monorepo-guidelines.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/118/files#diff-9274d21b31786b92badb27529fe55af4d42e1c898020e547e1c5b60c8ad56899) to understand the standardized package.json structure, then review any of the modified example package.json files like [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/118/files#diff-cafce8451c91c9a8cedfbbf1ad7fd4898cf0e1373850b0bdd284a3aff006965d) to verify the changes.

----

_[Macroscope](https://app.macroscope.com) summarized bf50bec._