### PR TITLE
Upgrade node 2.0.3 and gpt 4.1-mini

### DIFF
--- a/.cursor/rules/xmtp.md
+++ b/.cursor/rules/xmtp.md
@@ -27,7 +27,8 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```typescript
     const signer = createSigner(WALLET_KEY);
     const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
-    const client = await Client.create(signer, encryptionKey, {
+    const client = await Client.create(signer, {
+      dbEncryptionKey: encryptionKey,
       env: XMTP_ENV as XmtpEnv,
     });
     ```
@@ -776,7 +777,6 @@ When working with these classes:
 
 1. **Client**
 
-   - Created with `Client.create(signer, encryptionKey, options)`
    - Gateway to all XMTP functionality
    - Contains the conversations, contacts, and content types registries
 

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -3,4 +3,827 @@ description:
 globs: 
 alwaysApply: true
 ---
-[xmtp.md](mdc:.cursor/rules/xmtp.md)
+g XMTP Agents
+
+You're an expert in writing TypeScript with Node.js. Generate **high-quality XMTP Agents** that adhere to the following best practices:
+
+## Guidelines
+
+1.  Use modern TypeScript patterns and ESM modules. All examples should be structured as ES modules with `import` statements rather than CommonJS `require()`.
+
+2.  Use the XMTP node-sdk version "2.0.2" or newer, which offers enhanced functionality including group conversations.
+
+3.  Only import from @xmtp/node-sdk for XMTP functionality. Do not import from any other XMTP-related packages or URLs. Specifically:
+
+    - Never use the deprecated @xmtp/xmtp-js library, which has been completely replaced by @xmtp/node-sdk
+    - Always import directly from @xmtp/node-sdk as shown below:
+
+    ```typescript
+    // CORRECT:
+    import { Client, type Conversation, type XmtpEnv } from "@xmtp/node-sdk";
+
+    // INCORRECT - DEPRECATED:
+    import { Client } from "@xmtp/xmtp-js";
+    import { XmtpClient } from "some-other-package";
+    ```
+
+4.  Follow the consistent pattern for initializing XMTP clients:
+
+    ```typescript
+    const signer = createSigner(WALLET_KEY);
+    const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+    const client = await Client.create(signer, {
+      dbEncryptionKey: encryptionKey,
+      env: XMTP_ENV as XmtpEnv,
+    });
+    ```
+
+5.  Use proper environment variable validation at the start of each application. Check for required environment variables and show descriptive errors if missing.
+
+6.  Never use the concept of "topic" when working with XMTP. The current SDK doesn't use topics for message organization - work directly with conversations, groups, and DMs instead.
+
+7.  Handle both Group and DM conversations properly. The `Group` and `Dm` classes extend the `Conversation` class and provide specific functionality:
+
+    ```typescript
+    if (conversation instanceof Group) {
+      // Group-specific functionality like group.name or group.addMembers
+    } else if (conversation instanceof Dm) {
+      // DM-specific functionality like conversation.peerInboxId
+    }
+    ```
+
+8.  Always sync conversations before streaming messages:
+
+    ```typescript
+    await client.conversations.sync();
+    const stream = client.conversations.streamAllMessages();
+    ```
+
+9.  Filter out messages from the agent itself to prevent endless loops:
+
+    ```typescript
+    if (message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+    ```
+
+10. Consistent error handling pattern with try/catch blocks and specific error messages.
+
+11. Use the helper functions from the shared helpers directory for common operations:
+
+    - `createSigner` - Creates a signer from a private key
+    - `getEncryptionKeyFromHex` - Converts a hex string to an encryption key
+
+12. Always import helpers from the `@helpers` path, not from a relative path:
+
+    ```typescript
+    // CORRECT:
+    import { createSigner, getEncryptionKeyFromHex } from "@helpers/client";
+
+    // INCORRECT:
+    import { createSigner, getEncryptionKeyFromHex } from "./helpers";
+    ```
+
+13. When creating a group, use the correct options interface:
+
+    ```typescript
+    // CORRECT:
+    const group = await client.conversations.newGroup([inboxId], {
+      groupName: "My Group Name",
+      groupDescription: "My group description",
+      groupImageUrlSquare: "https://example.com/image.jpg",
+    });
+
+    // INCORRECT:
+    const group = await client.conversations.newGroup([inboxId], {
+      metadata: {
+        name: "My Group Name",
+      },
+    });
+    ```
+
+14. When checking message content types, use string literals instead of importing a non-existent ContentTypeId enum:
+
+    ```typescript
+    // CORRECT:
+    if (message?.contentType?.typeId !== "text") {
+      continue;
+    }
+
+    // INCORRECT:
+    import { ContentTypeId } from "@xmtp/node-sdk";
+    if (message?.contentType?.typeId !== ContentTypeId.Text) {
+      continue;
+    }
+    ```
+
+15. Get information about a message sender by using the conversation's members method, not by trying to call a non-existent sender() method on the message:
+
+    ```typescript
+    // CORRECT: Use inboxStateFromInboxIds to get the address from the inboxId
+    const inboxState = await client.preferences.inboxStateFromInboxIds([
+      message.senderInboxId,
+    ]);
+    // assuming there is 1 only one identifier
+    const addressFromInboxId = inboxState[0].identifiers[0].identifier;
+
+    // INCORRECT:
+    const sender = await message.sender();
+    const senderAddress = sender.accountIdentifiers[0].identifier;
+    ```
+
+16. Remember that ALL conversation types (including DMs) have a members() method. Don't check for "members" in an object:
+
+    ```typescript
+    // CORRECT:
+    const members = await conversation.members();
+
+    // INCORRECT:
+    if (conversation && "members" in conversation) {
+      const members = await conversation.members();
+    }
+    ```
+
+17. Always use toLowerCase() when comparing inboxIds or addresses:
+
+    ```typescript
+    // CORRECT:
+    if (message.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+
+    // INCORRECT:
+    if (message.senderInboxId === client.inboxId) {
+      continue;
+    }
+    ```
+
+18. Use consistent error handling pattern with type narrowing for unknown errors:
+
+    ```typescript
+    // CORRECT:
+    try {
+      // code that might throw
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.error("Error:", errorMessage);
+    }
+
+    // INCORRECT:
+    try {
+      // code that might throw
+    } catch (error) {
+      console.error("Error:", error);
+    }
+    ```
+
+19. Always use the built-in key generation command instead of creating your own script:
+
+    Environment variables
+
+    To run your XMTP agent, you must create a `.env` file with the following variables:
+
+    ```bash
+    WALLET_KEY= # the private key of the wallet
+    ENCRYPTION_KEY= # encryption key for the local database
+    XMTP_ENV=dev # local, dev, production
+    ```
+
+    Generating XMTP Keys
+
+    Always use the built-in key generation command instead of creating your own script:
+
+    ```bash
+    # Generate generic keys
+    yarn gen:keys
+    ```
+
+    This command will:
+
+    1. Generate a secure wallet private key
+    2. Create an encryption key for the local database
+    3. Output the corresponding public key
+    4. Automatically append the keys to your `.env` file
+
+    Example output in `.env`:
+
+    ```bash
+    # Generic keys
+    WALLET_KEY=0x...
+    ENCRYPTION_KEY=...
+    XMTP_ENV=dev
+    # public key is 0x...
+    ```
+
+    > [!IMPORTANT]
+    > Never create your own key generation script. The built-in command follows security best practices and uses the correct dependencies
+
+## Example: XMTP Group Creator Agent
+
+### Prompt:
+
+"Create an XMTP agent that creates a group for each message received that includes the sender (by inbox ID) and adds this member by address 0x7c40611372d354799d138542e77243c284e460b2. All members should be admins. The group name should be 'New group {message content}' with content being dynamic and the text message itself. After creating the group, it sends a message with the inbox ID, address, and installation ID of each user."
+
+### Solution:
+
+```typescript
+import { createSigner, getEncryptionKeyFromHex } from "@helpers/client";
+import { logAgentDetails, validateEnvironment } from "@helpers/utils";
+import { Client, IdentifierKind } from "@xmtp/node-sdk";
+
+/* Get the wallet key associated to the public key of
+ * the agent and the encryption key for the local db
+ * that stores your agent's messages */
+const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
+  "WALLET_KEY",
+  "ENCRYPTION_KEY",
+  "XMTP_ENV",
+]);
+
+// Define the address to always add to new groups
+const MEMBER_ADDRESS = "0x7c40611372d354799d138542e77243c284e460b2";
+
+async function main() {
+  // Initialize client
+  const signer = createSigner(WALLET_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
+    env: XMTP_ENV as XmtpEnv,
+  });
+
+  logAgentDetails(client);
+
+  console.log("✓ Syncing conversations...");
+  /* Sync the conversations from the network to update the local db */
+  await client.conversations.sync();
+
+  // Start listening for messages
+  console.log("Waiting for messages...");
+  const stream = await client.conversations.streamAllMessages();
+
+  for await (const message of stream) {
+    /* Ignore messages from the same agent or non-text messages */
+    if (
+      message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase() ||
+      message?.contentType?.typeId !== "text"
+    ) {
+      continue;
+    }
+
+    try {
+      // Get message content and sender inbox ID
+      const messageContent = message.content as string;
+      console.log(`Received message: ${messageContent}`);
+      const senderInboxId = message.senderInboxId;
+
+      // Get the conversation to reply to the sender
+      const conversation = await client.conversations.getConversationById(
+        message.conversationId,
+      );
+
+      if (!conversation) {
+        console.log("Could not find the conversation for the message");
+        continue;
+      }
+
+      // Create a group name based on the message content
+      const groupName = `New group ${messageContent}`;
+
+      // Create a new group including the sender and the specified address
+      console.log(
+        `Creating group "${groupName}" with sender ${senderInboxId}...`,
+      );
+
+      // Create group with sender first
+      const group = await client.conversations.newGroup([senderInboxId], {
+        groupName: groupName,
+        groupDescription: "Group created by message agent",
+      });
+
+      // Add the specified address as a member
+      await group.addMembersByIdentifiers([
+        {
+          identifier: MEMBER_ADDRESS,
+          identifierKind: IdentifierKind.Ethereum,
+        },
+      ]);
+
+      // Get group members for response
+      const members = await group.members();
+      const memberDetails = [];
+
+      for (const member of members) {
+        let ethAddress = "Unknown";
+        const ethIdentifier = member.accountIdentifiers.find(
+          (id) => id.identifierKind === IdentifierKind.Ethereum,
+        );
+
+        if (ethIdentifier) {
+          ethAddress = ethIdentifier.identifier;
+        }
+
+        let installationId = "Unknown";
+        if (member.installationIds && member.installationIds.length > 0) {
+          installationId = member.installationIds[0];
+        }
+
+        memberDetails.push({
+          inboxId: member.inboxId,
+          address: ethAddress,
+          installationId: installationId,
+        });
+      }
+
+      // Make all members admins
+      for (const member of members) {
+        if (member.inboxId.toLowerCase() !== client.inboxId.toLowerCase()) {
+          await group.addAdmin(member.inboxId);
+        }
+      }
+
+      // Send member details as response in the group
+      const responseMessage = `Group created with members:\n${memberDetails
+        .map(
+          (m) =>
+            `- Inbox ID: ${m.inboxId}\n  Address: ${m.address}\n  Installation ID: ${m.installationId}`,
+        )
+        .join("\n\n")}`;
+
+      await group.send(responseMessage);
+
+      // Reply to original conversation
+      await conversation.send(
+        `Created group "${groupName}" with you and ${MEMBER_ADDRESS}. All members have admin privileges.`,
+      );
+
+      console.log(
+        `Group "${groupName}" created successfully with ${members.length} members`,
+      );
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.error("Error processing message:", errorMessage);
+
+      // Try to send an error response
+      try {
+        const conversation = await client.conversations.getConversationById(
+          message.conversationId,
+        );
+        if (conversation) {
+          await conversation.send(
+            "Sorry, I encountered an error creating the group.",
+          );
+        }
+      } catch (sendError) {
+        console.error(
+          "Failed to send error message:",
+          sendError instanceof Error ? sendError.message : String(sendError),
+        );
+      }
+    }
+  }
+}
+
+main().catch(console.error);
+```
+
+## XMTP Helper Functions
+
+```typescript
+import { getRandomValues } from "node:crypto";
+import { IdentifierKind, type Signer } from "@xmtp/node-sdk";
+import { fromString, toString } from "uint8arrays";
+import { createWalletClient, http, toBytes } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+
+interface User {
+  key: `0x${string}`;
+  account: ReturnType<typeof privateKeyToAccount>;
+  wallet: ReturnType<typeof createWalletClient>;
+}
+
+export const createUser = (key: `0x${string}`): User => {
+  const accountKey = key;
+  const account = privateKeyToAccount(accountKey);
+  return {
+    key: accountKey,
+    account,
+    wallet: createWalletClient({
+      account,
+      chain: sepolia,
+      transport: http(),
+    }),
+  };
+};
+
+export const createSigner = (key: `0x${string}`): Signer => {
+  const user = createUser(key);
+  return {
+    type: "EOA",
+    getIdentifier: () => ({
+      identifierKind: IdentifierKind.Ethereum,
+      identifier: user.account.address.toLowerCase(),
+    }),
+    signMessage: async (message: string) => {
+      const signature = await user.wallet.signMessage({
+        message,
+        account: user.account,
+      });
+      return toBytes(signature);
+    },
+  };
+};
+
+/**
+ * Generate a random encryption key
+ * @returns The encryption key
+ */
+export const generateEncryptionKeyHex = () => {
+  /* Generate a random encryption key */
+  const uint8Array = getRandomValues(new Uint8Array(32));
+  /* Convert the encryption key to a hex string */
+  return toString(uint8Array, "hex");
+};
+
+/**
+ * Get the encryption key from a hex string
+ * @param hex - The hex string
+ * @returns The encryption key
+ */
+export const getEncryptionKeyFromHex = (hex: string) => {
+  /* Convert the hex string to an encryption key */
+  return fromString(hex, "hex");
+};
+```
+
+## XMTP Packages Reference
+
+```tsx
+// Client Class
+declare class Client {
+  constructor(client: Client$1, signer: Signer, codecs: ContentCodec[]);
+```
+
+## XMTP Identifiers Reference
+
+When working with XMTP, you'll encounter several types of identifiers:
+
+### Ethereum Addresses
+
+- Format: `0x` followed by 40 hexadecimal characters
+- Example: `0xfb55CB623f2aB58Da17D8696501054a2ACeD1944`
+- Usage: Identifies blockchain wallets associated with XMTP users
+
+### Private Key
+
+- Format: `0x` followed by 64 hexadecimal characters
+- Example: `0x11567776b95bdbed513330f503741e19877bf7fe73e7957bf6f0ecf3e267fdb8`
+- Usage: Used to create the signer for authenticating with XMTP
+
+### Encryption Key
+
+- Format: 64 hexadecimal characters (without "0x" prefix)
+- Example: `11973168e34839f9d31749ad77204359c5c39c404e1154eacb7f35a867ee47de`
+- Usage: Used for encrypting the local database
+
+### Inbox ID
+
+- Format: 64 hexadecimal characters (without "0x" prefix)
+- Example: `1180478fde9f6dfd4559c25f99f1a3f1505e1ad36b9c3a4dd3d5afb68c419179`
+- Usage: Primary identifier for XMTP conversations
+
+### Installation ID
+
+- Format: 64 hexadecimal characters (without "0x" prefix)
+- Example: `a83166f3ab057f28d634cc04df5587356063dba11bf7d6bcc08b21a8802f4028`
+- Usage: Identifies a specific XMTP client installation
+- Access via `member.installationIds` array on GroupMember objects
+
+### Example User Credentials Set
+
+```json
+{
+  "accountAddress": "0xfb55CB623f2aB58Da17D8696501054a2ACeD1944",
+  "privateKey": "0x11567776b95bdbed513330f503741e19877bf7fe73e7957bf6f0ecf3e267fdb8",
+  "encryptionKey": "11973168e34839f9d31749ad77204359c5c39c404e1154eacb7f35a867ee47de",
+  "inboxId": "1180478fde9f6dfd4559c25f99f1a3f1505e1ad36b9c3a4dd3d5afb68c419179",
+  "installationId": "a83166f3ab057f28d634cc04df5587356063dba11bf7d6bcc08b21a8802f4028"
+}
+```
+
+## Working with Members
+
+All conversations, both Groups and DMs, have a members() method that returns an array of GroupMember objects:
+
+```typescript
+// Get members from any conversation type (DM or Group)
+const members = await conversation.members();
+
+// Find a specific member
+const member = members.find(
+  (member) => member.inboxId.toLowerCase() === targetInboxId.toLowerCase(),
+);
+
+// Get member's Ethereum address
+if (member) {
+  const ethIdentifier = member.accountIdentifiers.find(
+    (id) => id.identifierKind === IdentifierKind.Ethereum,
+  );
+
+  if (ethIdentifier) {
+    const ethereumAddress = ethIdentifier.identifier;
+    console.log(`Found Ethereum address: ${ethereumAddress}`);
+  }
+
+  // Get installation ID
+  if (member.installationIds.length > 0) {
+    const installationId = member.installationIds[0];
+    console.log(`Found installation ID: ${installationId}`);
+  }
+}
+```
+
+## Working with Conversations
+
+XMTP provides two main conversation types:
+
+### Direct Messages (DMs)
+
+```typescript
+// Create a new DM
+const dm = await client.conversations.newDm("inboxId123");
+
+// Or create using an Ethereum address
+const dmByAddress = await client.conversations.newDmWithIdentifier({
+  identifier: "0x7c40611372d354799d138542e77243c284e460b2",
+  identifierKind: IdentifierKind.Ethereum,
+});
+
+// Send a message
+await dm.send("Hello!");
+
+// Access peer's inbox ID
+const peerInboxId = dm.peerInboxId;
+```
+
+### Groups
+
+```typescript
+// Create a new group
+const group = await client.conversations.newGroup(["inboxId1", "inboxId2"], {
+  groupName: "My Group",
+  groupDescription: "Group description",
+});
+
+// Update group metadata
+await group.updateName("New Group Name");
+await group.updateDescription("Updated description");
+
+// Manage members
+await group.addMembers(["newMemberInboxId"]);
+await group.removeMembers(["memberToRemoveInboxId"]);
+
+// Manage permissions
+await group.addAdmin("memberInboxId");
+await group.addSuperAdmin("memberInboxId");
+```
+
+## Group Creation Options
+
+When creating a new group, use the correct options interface:
+
+```typescript
+export interface CreateGroupOptions {
+  permissions?: GroupPermissionsOptions;
+  groupName?: string;
+  groupImageUrlSquare?: string;
+  groupDescription?: string;
+  customPermissionPolicySet?: PermissionPolicySet;
+  messageDisappearingSettings?: MessageDisappearingSettings;
+}
+```
+
+Example usage:
+
+```typescript
+// Create a group with some initial settings
+const group = await client.conversations.newGroup([inboxId1, inboxId2], {
+  groupName: "Project Discussion",
+  groupDescription: "A group for our project collaboration",
+  groupImageUrlSquare: "https://example.com/image.jpg",
+});
+
+// Update group settings later
+await group.updateName("Updated Project Name");
+await group.updateDescription("Our awesome project discussion");
+await group.updateImageUrl("https://example.com/new-image.jpg");
+```
+
+## Fetching Messages
+
+There are two ways to retrieve messages from conversations:
+
+### 1. Streaming Messages (Recommended for Agents)
+
+Stream all messages to process them in real-time:
+
+```typescript
+const stream = await client.conversations.streamAllMessages();
+for await (const message of stream) {
+  // Process each message as it arrives
+  console.log(`Received message: ${message.content as string}`);
+}
+```
+
+### 2. Polling Messages
+
+Retrieve all messages at once from the local database:
+
+```typescript
+// First sync the conversations from the network to update the local db
+await client.conversations.sync();
+
+// Then get all messages as an array
+const messages = await conversation.messages();
+```
+
+## Key Type References
+
+```tsx
+// Client Class
+declare class Client {
+  constructor(client: Client$1, signer: Signer, codecs: ContentCodec[]);
+  static create(
+    signer: Signer,
+    encryptionKey: Uint8Array,
+    options?: ClientOptions,
+  ): Promise<Client>;
+  get inboxId(): string;
+  get installationId(): string;
+  get conversations(): Conversations;
+  get preferences(): Preferences;
+}
+
+// Conversations Class
+declare class Conversations {
+  constructor(client: Client, conversations: Conversations$1);
+  getConversationById(id: string): Promise<Dm | Group | undefined>;
+  newGroupWithIdentifiers(
+    identifiers: Identifier[],
+    options?: CreateGroupOptions,
+  ): Promise<Group>;
+  newGroup(inboxIds: string[], options?: CreateGroupOptions): Promise<Group>;
+  newDmWithIdentifier(
+    identifier: Identifier,
+    options?: CreateDmOptions,
+  ): Promise<Dm>;
+  newDm(inboxId: string, options?: CreateDmOptions): Promise<Dm>;
+  sync(): Promise<void>;
+  streamAllMessages(
+    callback?: StreamCallback<DecodedMessage>,
+  ): Promise<AsyncStream<DecodedMessage<any>>>;
+}
+
+// Conversation Base Class
+declare class Conversation {
+  client: Client;
+  constructor(
+    client: Client,
+    conversation: Conversation$1,
+    lastMessage?: Message | null,
+  );
+  get id(): string;
+  send<T>(content: T, options?: SendOptions): Promise<string>;
+  messages<T>(options?: PaginationOptions): Promise<Array<DecodedMessage<T>>>;
+  members(): Promise<GroupMember[]>;
+}
+
+// Dm Class
+declare class Dm extends Conversation {
+  constructor(
+    client: Client,
+    conversation: Conversation$1,
+    lastMessage?: Message | null,
+  );
+  get peerInboxId(): string;
+}
+
+// Group Class
+declare class Group extends Conversation {
+  constructor(
+    client: Client,
+    conversation: Conversation$1,
+    lastMessage?: Message | null,
+  );
+  get name(): string;
+  updateName(name: string): Promise<void>;
+  get imageUrl(): string;
+  updateImageUrl(imageUrl: string): Promise<void>;
+  get description(): string;
+  updateDescription(description: string): Promise<void>;
+  get admins(): string[];
+  get superAdmins(): string[];
+  isAdmin(inboxId: string): boolean;
+  isSuperAdmin(inboxId: string): boolean;
+  addMembersByIdentifiers(identifiers: Identifier[]): Promise<void>;
+  addMembers(inboxIds: string[]): Promise<void>;
+  removeMembers(inboxIds: string[]): Promise<void>;
+  addAdmin(inboxId: string): Promise<void>;
+  removeAdmin(inboxId: string): Promise<void>;
+  addSuperAdmin(inboxId: string): Promise<void>;
+  removeSuperAdmin(inboxId: string): Promise<void>;
+}
+
+// GroupMember Class
+declare class GroupMember {
+  inboxId: string;
+  accountIdentifiers: Array<Identifier>;
+  installationIds: Array<string>;
+  permissionLevel: PermissionLevel;
+  consentState: ConsentState;
+}
+
+// DecodedMessage Class
+declare class DecodedMessage<T = any> {
+  content: T;
+  contentType: ContentTypeId | undefined;
+  conversationId: string;
+  id: string;
+  senderInboxId: string;
+  sentAt: Date;
+  constructor(client: Client, message: Message);
+}
+
+// Identifier Interface
+export interface Identifier {
+  identifier: string;
+  identifierKind: IdentifierKind;
+}
+
+export declare const enum IdentifierKind {
+  Ethereum = 0,
+  Passkey = 1,
+}
+
+// CreateGroupOptions Interface
+export interface CreateGroupOptions {
+  groupName?: string;
+  groupImageUrlSquare?: string;
+  groupDescription?: string;
+}
+```
+
+### Common Usage Patterns
+
+When working with these classes:
+
+1. **Client**
+
+   - Gateway to all XMTP functionality
+   - Contains the conversations, contacts, and content types registries
+
+2. **Conversations**
+
+   - Central interface for managing all conversations
+   - Use `sync()` before accessing local conversation data
+   - Use `streamAllMessages()` to listen for new messages in real-time
+   - Create conversations with `newDm()`, `newGroup()`, etc.
+
+3. **Dm**
+
+   - Access the peer using `conversation.peerInboxId`
+   - Create new DMs with `client.conversations.newDm(inboxId)`
+   - Send messages with `dm.send(content)`
+
+4. **Group**
+
+   - Get members with `await group.members();` (this works for DMs too)
+   - Manage group metadata with `updateName()`, `updateDescription()`, etc.
+   - Add/remove members with `addMembers()` and `removeMembers()`
+   - Manage permissions with admin methods: `addAdmin()`, `addSuperAdmin()`, etc.
+   - Check permissions with `isAdmin()` and `isSuperAdmin()`
+
+5. **GroupMember**
+   - Use `member.inboxId` to identify members
+   - Access Ethereum addresses through `member.accountIdentifiers`
+   - Access installation IDs through `member.installationIds`
+   - Check permission level with `member.permissionLevel`
+   - Verify consent state with `member.consentState`
+
+## Other Notes
+
+### Handling local database paths
+
+```jsx
+// Railway deployment support
+let volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
+const dbPath = `${volumePath}/${signer.getIdentifier()}-${XMTP_ENV}`;
+
+// Create database directory if it doesn't exist
+if (!fs.existsSync(dbPath)) {
+  fs.mkdirSync(dbPath, { recursive: true });
+}
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains examples of agents that use the [XMTP](https://docs.xmt
 ## Getting started
 
 > [!TIP]
-> See XMTP's [cursor rules](/.cursor/rules/xmtp.md) for vibe coding agents and best practices.
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
 
 ### Requirements
 

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -138,7 +138,7 @@ async function initializeAgent(
 ): Promise<{ agent: Agent; config: AgentConfig }> {
   try {
     const llm = new ChatOpenAI({
-      model: "gpt-4o-mini",
+      model: "gpt-4.1-mini",
     });
 
     const storedWalletData = getWalletData(userId);

--- a/examples/xmtp-gaia/package.json
+++ b/examples/xmtp-gaia/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@xmtp/node-sdk": "*",
-    "openai": "latest"
+    "openai": "4.94.0"
   },
   "devDependencies": {
     "tsx": "*",

--- a/examples/xmtp-gpt/index.ts
+++ b/examples/xmtp-gpt/index.ts
@@ -68,7 +68,7 @@ async function main() {
       /* Get the AI response */
       const completion = await openai.chat.completions.create({
         messages: [{ role: "user", content: message.content as string }],
-        model: "gpt-3.5-turbo",
+        model: "gpt-4.1-mini",
       });
 
       /* Get the AI response */

--- a/examples/xmtp-gpt/package.json
+++ b/examples/xmtp-gpt/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@xmtp/node-sdk": "*",
-    "openai": "latest"
+    "openai": "4.94.0"
   },
   "devDependencies": {
     "tsx": "*",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "typecheck": "tsc"
   },
   "resolutions": {
-    "@xmtp/node-sdk": "2.0.2"
+    "@xmtp/node-sdk": "2.0.3"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "^2.0.2",
+    "@xmtp/node-sdk": "^2.0.3",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,23 +1983,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:^1.2.0-dev.bed98df":
-  version: 1.2.0-dev.bed98df
-  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.bed98df"
-  checksum: 10/a7e57fb3a1fa462ba49be33ad4ec05e3f164cfd198b5011a12968e57f477abe822c754a74a6fb7b529789408caee38ed1291e1e0165b4f5f3969e50ce98d1e15
+"@xmtp/node-bindings@npm:1.2.0-dev.c24af30":
+  version: 1.2.0-dev.c24af30
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.c24af30"
+  checksum: 10/51ba1d46bbf6016e9eaa6c9909f39392ea3bc48826f61514b9b68dcc706f9d3318c0eb283cdcba30bc5fc65e8c6f3614610231b92548bc2722e0aa70090d655b
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:2.0.2":
-  version: 2.0.2
-  resolution: "@xmtp/node-sdk@npm:2.0.2"
+"@xmtp/node-sdk@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@xmtp/node-sdk@npm:2.0.3"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
+    "@xmtp/node-bindings": "npm:1.2.0-dev.c24af30"
     "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/c75bb2a4f218baed1145a2546b3f2c552c8ea5ec866f806bea192b59854172bb44f75568eafdc3e19ef9a949514243fca68fdb38bd06000fe88021e3e1f8912f
+  checksum: 10/73f5377f18ed75840c87f5e05dc4d3380ab6c1616aedbe81354a4a20edfbae9b499cecc5dd1d04e35372c259351abafd130faa8c242274a778508c9a43be7d42
   languageName: node
   linkType: hard
 
@@ -5594,7 +5594,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:^2.0.2"
+    "@xmtp/node-sdk": "npm:^2.0.3"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,7 +924,7 @@ __metadata:
   resolution: "@examples/xmtp-gaia@workspace:examples/xmtp-gaia"
   dependencies:
     "@xmtp/node-sdk": "npm:*"
-    openai: "npm:latest"
+    openai: "npm:4.94.0"
     tsx: "npm:*"
     typescript: "npm:*"
   languageName: unknown
@@ -945,7 +945,7 @@ __metadata:
   resolution: "@examples/xmtp-gpt@workspace:examples/xmtp-gpt"
   dependencies:
     "@xmtp/node-sdk": "npm:*"
-    openai: "npm:latest"
+    openai: "npm:4.94.0"
     tsx: "npm:*"
     typescript: "npm:*"
   languageName: unknown
@@ -4367,7 +4367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^4.77.0, openai@npm:latest":
+"openai@npm:4.94.0, openai@npm:^4.77.0":
   version: 4.94.0
   resolution: "openai@npm:4.94.0"
   dependencies:


### PR DESCRIPTION
### Update XMTP client initialization pattern and upgrade AI models to use `gpt-4.1-mini` and `@xmtp/node-sdk` v2.0.3
* Updates XMTP client initialization in [`xmtp.md`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-8a72fc951d2d2a49e17304ce7bfb7c5e5e7dca977a2db89ed7b77c1ec4fbad6e) to use a two-parameter pattern where `encryptionKey` is now part of the options object
* Changes AI model from `gpt-3.5-turbo` to `gpt-4.1-mini` in [`index.ts`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-15d6aa15c3ab27df52cef86d38f2bd99d547836e4b05ed510119c9aa34d90ef6) and [`index.ts`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-b7bfbea16a422f169ef1ed3b4d8a2ce445a4e156099da3c36089bf91b538e752)
* Pins `openai` package to version 4.94.0 in [`package.json`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-bf755da31fcc99af38cf36a778710ba0e33568a0fc829abcf975989dee421dd8) and [`package.json`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-cafce8451c91c9a8cedfbbf1ad7fd4898cf0e1373850b0bdd284a3aff006965d)
* Updates `@xmtp/node-sdk` from v2.0.2 to v2.0.3 in [`package.json`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
* Expands XMTP documentation in [`xmtp.mdc`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20)

#### 📍Where to Start
Start with the XMTP client initialization pattern changes in [`xmtp.md`](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/121/files#diff-8a72fc951d2d2a49e17304ce7bfb7c5e5e7dca977a2db89ed7b77c1ec4fbad6e), as this represents the core API change that affects how developers will initialize the XMTP client.

----

_[Macroscope](https://app.macroscope.com) summarized de7b9cf._