### PR TITLE
Improve dual client example

### DIFF
--- a/examples/xmtp-dual-client/index.ts
+++ b/examples/xmtp-dual-client/index.ts
@@ -66,7 +66,7 @@ async function startReceiver(receiverClient: Client): Promise<void> {
   console.log("Starting receiver...");
 
   // Set up periodic sync
-  setInterval(() => {
+  const syncIntervalId = setInterval(() => {
     void sync(receiverClient);
   }, SYNC_INTERVAL);
 
@@ -103,6 +103,9 @@ async function startReceiver(receiverClient: Client): Promise<void> {
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error("Error in receiver stream:", errorMessage);
+
+    // Clear the interval before restarting
+    clearInterval(syncIntervalId);
 
     // Restart receiver after delay on error
     setTimeout(() => {


### PR DESCRIPTION
### Increase XMTP dual-client sync frequency from 60 to 0.5 seconds to replicate rate limiting in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/126/files#diff-9ea31d5689afed035aec82029d9b070215136906b9082c8d03fec97580f2db88)
* Refactors the dual-client XMTP agent in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/126/files#diff-9ea31d5689afed035aec82029d9b070215136906b9082c8d03fec97580f2db88) to use a 500ms sync interval
* Extracts sync functionality into a dedicated `sync()` function
* Adds automatic restart capability for the receiver process
* Modifies database path naming to include XMTP environment
* Removes priority-based retry mechanism for failed message sends

#### 📍Where to Start
Start with the `main()` function in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/126/files#diff-9ea31d5689afed035aec82029d9b070215136906b9082c8d03fec97580f2db88) which initializes the dual-client setup and coordinates the sender and receiver processes.

----

_[Macroscope](https://app.macroscope.com) summarized 46c478a._