### PR TITLE
Refactor dbPath handling for better Railway support

### DIFF
--- a/.cursor/rules/xmtp.md
+++ b/.cursor/rules/xmtp.md
@@ -854,20 +854,23 @@ When working with these classes:
 If no `dbPath` is provided, the client will use the current working directory. You can also specify a custom path for the database.
 
 ```jsx
-// Railway deployment support
-let volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
-const dbPath = `${volumePath}/${signer.getIdentifier()}-${XMTP_ENV}`;
+export const getDbPath = (env: string, suffix: string = "xmtp") => {
+  //Checks if the environment is a Railway deployment
+  const volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
+  // Create database directory if it doesn't exist
+  if (!fs.existsSync(volumePath)) {
+    fs.mkdirSync(volumePath, { recursive: true });
+  }
+  const dbPath = `${volumePath}/${env}-${suffix}.db3`;
 
-// Create database directory if it doesn't exist
-if (!fs.existsSync(dbPath)) {
-  fs.mkdirSync(dbPath, { recursive: true });
-}
+  return dbPath;
+};
 
 // Create a client with db path
 const client = await Client.create(signer, {
   dbEncryptionKey,
   env: XMTP_ENV as XmtpEnv,
   // Use a unique DB directory
-  dbPath,
+  dbPath:getDbPath(XMTP_ENV),
 });
 ```

--- a/.cursor/rules/xmtp.md
+++ b/.cursor/rules/xmtp.md
@@ -854,23 +854,21 @@ When working with these classes:
 If no `dbPath` is provided, the client will use the current working directory. You can also specify a custom path for the database.
 
 ```jsx
-export const getDbPath = (env: string, suffix: string = "xmtp") => {
+export const getDbPath = (description: string = "xmtp") => {
   //Checks if the environment is a Railway deployment
   const volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
   // Create database directory if it doesn't exist
   if (!fs.existsSync(volumePath)) {
     fs.mkdirSync(volumePath, { recursive: true });
   }
-  const dbPath = `${volumePath}/${env}-${suffix}.db3`;
-
-  return dbPath;
+  return `${volumePath}/${description}.db3`;
 };
 
 // Create a client with db path
+const signerIdentifier = (await signer.getIdentifier()).identifier;
 const client = await Client.create(signer, {
   dbEncryptionKey,
   env: XMTP_ENV as XmtpEnv,
-  // Use a unique DB directory
-  dbPath:getDbPath(XMTP_ENV),
+  dbPath:getDbPath(XMTP_ENV+"-"+signerIdentifier),
 });
 ```

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -11,7 +11,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
 1.  Use modern TypeScript patterns and ESM modules. All examples should be structured as ES modules with `import` statements rather than CommonJS `require()`.
 
-2.  Use the XMTP node-sdk version "2.0.2" or newer, which offers enhanced functionality including group conversations.
+2.  Use the @xmtp/node-sdk and default to the latest version.
 
 3.  Only import from @xmtp/node-sdk for XMTP functionality. Do not import from any other XMTP-related packages or URLs. Specifically:
 
@@ -638,6 +638,45 @@ for await (const message of stream) {
 }
 ```
 
+This example implements a retry mechanism with configurable parameters:
+
+```tsx
+const MAX_RETRIES = 6; // 6 times
+const RETRY_DELAY_MS = 10000; // 10 seconds
+
+// Helper function to pause execution
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let retryCount = 0;
+
+while (retryCount < MAX_RETRIES) {
+  try {
+    console.log(
+      `Starting message stream... (attempt ${retryCount + 1}/${MAX_RETRIES})`,
+    );
+    const streamPromise = client.conversations.streamAllMessages();
+    const stream = await streamPromise;
+
+    console.log("Waiting for messages...");
+    for await (const message of stream) {
+      // Process messages here
+    }
+
+    // If we get here without an error, reset the retry count
+    retryCount = 0;
+  } catch (error) {
+    retryCount++;
+    console.debug(error);
+    if (retryCount < MAX_RETRIES) {
+      console.log(`Waiting ${RETRY_DELAY_MS / 1000} seconds before retry...`);
+      await sleep(RETRY_DELAY_MS);
+    } else {
+      console.log("Maximum retry attempts reached. Exiting.");
+    }
+  }
+}
+```
+
 ### 2. Polling Messages
 
 Retrieve all messages at once from the local database:
@@ -820,20 +859,23 @@ When working with these classes:
 If no `dbPath` is provided, the client will use the current working directory. You can also specify a custom path for the database.
 
 ```jsx
-// Railway deployment support
-let volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
-const dbPath = `${volumePath}/${signer.getIdentifier()}-${XMTP_ENV}`;
+export const getDbPath = (env: string, suffix: string = "xmtp") => {
+  //Checks if the environment is a Railway deployment
+  const volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
+  // Create database directory if it doesn't exist
+  if (!fs.existsSync(volumePath)) {
+    fs.mkdirSync(volumePath, { recursive: true });
+  }
+  const dbPath = `${volumePath}/${env}-${suffix}.db3`;
 
-// Create database directory if it doesn't exist
-if (!fs.existsSync(dbPath)) {
-  fs.mkdirSync(dbPath, { recursive: true });
-}
+  return dbPath;
+};
 
 // Create a client with db path
 const client = await Client.create(signer, {
   dbEncryptionKey,
   env: XMTP_ENV as XmtpEnv,
   // Use a unique DB directory
-  dbPath,
+  dbPath:getDbPath(XMTP_ENV),
 });
 ```

--- a/examples/xmtp-queue-dual-client/index.ts
+++ b/examples/xmtp-queue-dual-client/index.ts
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
     dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
-    dbPath: getDbPath(XMTP_ENV, "receiver"),
+    dbPath: getDbPath(XMTP_ENV + "-receiver"),
   });
   logAgentDetails(receiverClient);
   console.log("Installation A (receiver) client created");
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
     dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
-    dbPath: getDbPath(XMTP_ENV, "sender"),
+    dbPath: getDbPath(XMTP_ENV + "-sender"),
   });
   console.log("Installation B (sender) client created");
 

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -65,14 +65,12 @@ export const getEncryptionKeyFromHex = (hex: string) => {
   return fromString(hex, "hex");
 };
 
-export const getDbPath = (env: string, suffix: string = "xmtp") => {
+export const getDbPath = (description: string = "xmtp") => {
   //Checks if the environment is a Railway deployment
   const volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
   // Create database directory if it doesn't exist
   if (!fs.existsSync(volumePath)) {
     fs.mkdirSync(volumePath, { recursive: true });
   }
-  const dbPath = `${volumePath}/${env}-${suffix}.db3`;
-
-  return dbPath;
+  return `${volumePath}/${description}.db3`;
 };

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "typecheck": "tsc"
   },
   "resolutions": {
-    "@xmtp/node-sdk": "2.0.6"
+    "@xmtp/node-sdk": "2.0.7"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "^2.0.6",
+    "@xmtp/node-sdk": "^2.0.7",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,16 +2058,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:2.0.6":
-  version: 2.0.6
-  resolution: "@xmtp/node-sdk@npm:2.0.6"
+"@xmtp/node-sdk@npm:2.0.7":
+  version: 2.0.7
+  resolution: "@xmtp/node-sdk@npm:2.0.7"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/node-bindings": "npm:1.1.6"
     "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/734ff15f764a356f2e06b7b44849bf53b45032c6207d73d1005ca05dbd9df8d5008935b65f6f9ea64fcd7c137ecb4c5dc8eaec9e0afd36936a54e60140612edb
+  checksum: 10/7ace1b97165ddc42edf8e4ba24404912391c692f55bfbcaa4d367e83a8d78d1e4056c5cda4fc5d376b3c7da4cd6a169d47713e5c70dee4fe6ea2346c74663193
   languageName: node
   linkType: hard
 
@@ -5685,7 +5685,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:^2.0.6"
+    "@xmtp/node-sdk": "npm:^2.0.7"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"


### PR DESCRIPTION
### Standardize database path handling in XMTP client by implementing `getDbPath` function to support Railway deployment volumes
The database path handling logic has been centralized through a new `getDbPath` function in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/134/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1). Key changes include:

* Refactored `getDbPath` function to accept a single description parameter and handle Railway deployment volume paths
* Updated XMTP client initialization in [.cursor/rules/xmtp.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/134/files#diff-8a72fc951d2d2a49e17304ce7bfb7c5e5e7dca977a2db89ed7b77c1ec4fbad6e) to use explicit signer identifiers
* Modified dual client example in [examples/xmtp-queue-dual-client/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/134/files#diff-12206c096c41164388d4ee5667242d27e93e10d89e76540088a30724f4138ced) to use new `getDbPath` signature
* Added retry mechanism documentation for message streaming in [.cursor/rules/xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/134/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20)
* Updated @xmtp/node-sdk from version 2.0.6 to 2.0.7

#### 📍Where to Start
Start with the refactored `getDbPath` function implementation in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/134/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1), which is the core change that other files depend on.

----

_[Macroscope](https://app.macroscope.com) summarized 64db5f7._