### PR TITLE
Add TypeScript linting rules for better code clarity

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,13 @@ export default tseslint.config(
           allowNumber: true,
         },
       ],
+      "@typescript-eslint/ban-ts-comment": [
+        "warn",
+        {
+          "ts-expect-error": "allow-with-description",
+          minimumDescriptionLength: 3,
+        },
+      ],
     },
   },
   {
@@ -70,6 +77,12 @@ export default tseslint.config(
   },
   {
     files: ["**/xmtp-stream-restart/**"],
+    rules: {
+      "@typescript-eslint/no-unnecessary-condition": "off",
+    },
+  },
+  {
+    files: ["**/xmtp-deployment-example/**"],
     rules: {
       "@typescript-eslint/no-unnecessary-condition": "off",
     },

--- a/examples/xmtp-deployment-example/xmtp-handler.ts
+++ b/examples/xmtp-deployment-example/xmtp-handler.ts
@@ -138,7 +138,6 @@ export const initializeClient = async (
     const acceptTypes = options.acceptTypes || ["text"];
     let backoffTime = RETRY_DELAY_MS;
 
-    // Main stream loop - never exits
     while (true) {
       try {
         // Reset backoff time if we've been running successfully


### PR DESCRIPTION
### Configure ESLint to require descriptions for `@typescript-eslint/ban-ts-comment` and disable `no-unnecessary-condition` rule for XMTP deployment examples
* Added ESLint rule requiring descriptions of at least 3 characters for `ts-expect-error` comments in [eslint.config.js](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/140/files#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839)
* Disabled `@typescript-eslint/no-unnecessary-condition` rule for files in `**/xmtp-deployment-example/**` path
* Removed obsolete comment from `streamMessages` function in [xmtp-handler.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/140/files#diff-2acd68945437e399f1c93a837d98129e09a553f95506ff4f4904eaf391242ade)

#### 📍Where to Start
Start with the ESLint configuration changes in [eslint.config.js](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/140/files#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839) which contains the core rule modifications.

----

_[Macroscope](https://app.macroscope.com) summarized 6f8beb2._