### PR TITLE
Update XMTP SDK version for stability improvements

### DIFF
--- a/examples/xmtp-self-serve/package.json
+++ b/examples/xmtp-self-serve/package.json
@@ -11,7 +11,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "*"
+    "@xmtp/node-sdk": "2.0.9-dev.b8c42b4"
   },
   "devDependencies": {
     "tsx": "*",

--- a/examples/xmtp-self-serve/xmtp-handler.ts
+++ b/examples/xmtp-self-serve/xmtp-handler.ts
@@ -83,7 +83,6 @@ export const initializeClient = async (
     ...DEFAULT_AGENT_OPTIONS,
     ...opt,
   }));
-  console.log(mergedOptions);
 
   /**
    * Core message streaming function with robust error handling

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,7 +977,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-self-serve@workspace:examples/xmtp-self-serve"
   dependencies:
-    "@xmtp/node-sdk": "npm:*"
+    "@xmtp/node-sdk": "npm:2.0.9-dev.b8c42b4"
     tsx: "npm:*"
     typescript: "npm:*"
   languageName: unknown


### PR DESCRIPTION
### Pin XMTP SDK version to 2.0.9-dev.b8c42b4 in self-serve example for stability improvements
* Updates `@xmtp/node-sdk` dependency version from `*` to `2.0.9-dev.b8c42b4` in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/148/files#diff-1c5b24c11eead4a72f23f2c080696cb73e695354def14e8f6bc06ee00ea85104)
* Removes debug logging of merged options from `initializeClient` function in [xmtp-handler.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/148/files#diff-2705943c6fce849d143d613cf516c32e8bfaeaf146efbdab4365bc7b9a4ba460)
* Updates [yarn.lock](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/148/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect new dependency version

#### 📍Where to Start
Start with the dependency version update in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/148/files#diff-1c5b24c11eead4a72f23f2c080696cb73e695354def14e8f6bc06ee00ea85104), then review the removal of debug logging in the `initializeClient` function in [xmtp-handler.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/148/files#diff-2705943c6fce849d143d613cf516c32e8bfaeaf146efbdab4365bc7b9a4ba460).

----

_[Macroscope](https://app.macroscope.com) summarized e0c3b1b._