### PR TITLE
Add usage instructions for message handling and addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ We have a guide for deploying the agent on [Railway](https://github.com/ephemera
 
 ## Basic usage
 
+### Listening and sending messages
+
 These are the steps to initialize the XMTP listener and send messages.
 
 ```tsx
@@ -106,6 +108,20 @@ async function main() {
 main().catch(console.error);
 ```
 
+### Getting the address of a user
+
+Each user has a unique inbox id, which can be used to get the address associated with it.
+
+```tsx
+const inboxState = await client.preferences.inboxStateFromInboxIds([
+  message.senderInboxId,
+]);
+const addressFromInboxId = inboxState[0].identifiers[0].identifier;
+console.log(`Sending "gm" response to ${addressFromInboxId}...`);
+```
+
+_Keep in mind that not necessarily all users have an address associated with it._
+
 ## Examples
 
 - [xmtp-gm](/examples/xmtp-gm/): A simple agent that replies to all text messages with "gm".
@@ -132,3 +148,7 @@ This examples are outside of this monorepo and showcase how to use and deploy XM
 Interact with the XMTP network using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
 ![](/examples/xmtp-gm/screenshot.png)
+
+```
+
+```


### PR DESCRIPTION
### Document message handling and address retrieval functionality in XMTP README
Updates the [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/157/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with new documentation sections covering:

* Message handling instructions under "Basic usage" section, explaining listening and sending functionality
* Address retrieval documentation showing how to use `client.preferences.inboxStateFromInboxIds` to get a user's address from their inbox ID

#### 📍Where to Start
Start with the updated documentation sections in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/157/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), particularly the new "Listening and sending messages" and "Getting the address of a user" subsections.

----

_[Macroscope](https://app.macroscope.com) summarized b86bfaf._