### PR TITLE
Update @xmtp/node-sdk to version 2.1.0-rc4

### DIFF
--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -310,7 +310,7 @@ async function handleMessage(message: DecodedMessage, client: Client) {
  *
  * @param client - The XMTP client instance
  */
-async function startMessageListener(client: Client) {
+async function startMessageListener(client: Client<any>) {
   console.log("Starting message listener...");
   const stream = await client.conversations.streamAllMessages();
   for await (const message of stream) {

--- a/examples/xmtp-multiple-workers/workers.ts
+++ b/examples/xmtp-multiple-workers/workers.ts
@@ -13,7 +13,7 @@ export interface WorkerInstance {
   name: string;
   address: string;
   inboxId: string;
-  client: Client;
+  client: Client<any>;
   messageStream?: AsyncIterable<DecodedMessage>;
   isTerminated: boolean;
 }

--- a/examples/xmtp-queue-dual-client/index.ts
+++ b/examples/xmtp-queue-dual-client/index.ts
@@ -83,8 +83,8 @@ async function main(): Promise<void> {
  * Start periodic sync for both clients
  */
 function startPeriodicSync(
-  receivingClient: Client,
-  sendingClient: Client,
+  receivingClient: Client<any>,
+  sendingClient: Client<any>,
 ): void {
   console.log(`Setting up periodic sync every ${SYNC_INTERVAL} minutes`);
 
@@ -110,7 +110,7 @@ function startPeriodicSync(
   );
 }
 
-async function setupMessageStream(client: Client): Promise<void> {
+async function setupMessageStream(client: Client<any>): Promise<void> {
   try {
     console.log("Setting up message stream on receiving client...");
     const stream = await client.conversations.streamAllMessages();
@@ -153,7 +153,7 @@ async function setupMessageStream(client: Client): Promise<void> {
   }
 }
 
-function startMessageProcessor(client: Client): void {
+function startMessageProcessor(client: Client<any>): void {
   console.log("Starting message processor on sending client...");
   // Process message queue periodically
   setInterval(() => {

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -77,7 +77,7 @@ export const getDbPath = (description: string = "xmtp") => {
 };
 
 export const logAgentDetails = async (
-  clients: Client | Client[],
+  clients: Client<any> | Client<any>[],
 ): Promise<void> => {
   const clientsByAddress = Array.isArray(clients)
     ? clients.reduce<Record<string, Client[]>>((acc, client) => {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "typecheck": "tsc"
   },
   "resolutions": {
-    "@xmtp/node-sdk": "2.1.0-rc3"
+    "@xmtp/node-sdk": "2.1.0-rc4"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "2.1.0-rc3",
+    "@xmtp/node-sdk": "2.1.0-rc4",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,23 +2051,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:1.2.0-rc3":
-  version: 1.2.0-rc3
-  resolution: "@xmtp/node-bindings@npm:1.2.0-rc3"
-  checksum: 10/16c1acd9c975725a10e173f90b192595238f8d3cc4897bee1bde2689f79d585e469c46cb7cb9bb83928c351412369b9db3911d86622dae5172de535d06fc5b48
+"@xmtp/node-bindings@npm:1.2.0-rc4":
+  version: 1.2.0-rc4
+  resolution: "@xmtp/node-bindings@npm:1.2.0-rc4"
+  checksum: 10/aae164899c99bb1869212b3b41d9f15047e613f6692e775177c1898ec3ec78baa38614ad7381d6b9e646cebbb6d67002cb246ac4b8d28404e84f73cb6c76faac
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:2.1.0-rc3":
-  version: 2.1.0-rc3
-  resolution: "@xmtp/node-sdk@npm:2.1.0-rc3"
+"@xmtp/node-sdk@npm:2.1.0-rc4":
+  version: 2.1.0-rc4
+  resolution: "@xmtp/node-sdk@npm:2.1.0-rc4"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.0-rc3"
+    "@xmtp/node-bindings": "npm:1.2.0-rc4"
     "@xmtp/proto": "npm:^3.78.0"
-  checksum: 10/164fa266dc2d95b749e2945a34f57c50a9641491550fc38d7b526213bb130c86610ab71a56137c854e871aa3ac40249bfbf66a86b7b3d134b6d2320d89c1e756
+  checksum: 10/f4cb2b7994dfcdf41ac0d74014382809af2d92ac0e4e849db6e3c3e8e9da37d0c9cb43625da6578c8bb80f0f1b901ffbd806d71d0f55e135b0acd741157af5b6
   languageName: node
   linkType: hard
 
@@ -5685,7 +5685,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:2.1.0-rc3"
+    "@xmtp/node-sdk": "npm:2.1.0-rc4"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"


### PR DESCRIPTION
### Update @xmtp/node-sdk dependency from version 2.1.0-rc3 to 2.1.0-rc4 and modify Client type signatures to use generic Client<any> across multiple example files and helper functions
Updates the `@xmtp/node-sdk` dependency version in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and modifies type signatures across multiple files to use `Client<any>` instead of `Client`:

• Function signatures in [examples/xmtp-coinbase-agentkit/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-b7bfbea16a422f169ef1ed3b4d8a2ce445a4e156099da3c36089bf91b538e752), [examples/xmtp-queue-dual-client/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-12206c096c41164388d4ee5667242d27e93e10d89e76540088a30724f4138ced), and [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) updated to specify generic type parameter
• Interface definition for `WorkerInstance.client` property in [examples/xmtp-multiple-workers/workers.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-fc7a04ffb2ee146143cf201c0ec6b92f9fb33f2b92185605c3d1389f09f22e60) updated to use generic type
• Corresponding updates to [yarn.lock](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) file to reflect dependency changes

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the SDK update, then review the type signature changes in [examples/xmtp-coinbase-agentkit/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/160/files#diff-b7bfbea16a422f169ef1ed3b4d8a2ce445a4e156099da3c36089bf91b538e752) to see how the `Client<any>` generic type is being applied.

----

_[Macroscope](https://app.macroscope.com) summarized e61f924._