### PR TITLE
Add installation count to agent details log output

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -108,10 +108,12 @@ export const logAgentDetails = async (
     const urls = [`http://xmtp.chat/dm/${address}`];
 
     const conversations = await firstClient.conversations.list();
+    const installations = await firstClient.preferences.inboxState();
 
     console.log(`
     ✓ XMTP Client:
     • Address: ${address}
+    • Installations: ${installations.installations.length}
     • Conversations: ${conversations.length}
     • InboxId: ${inboxId}
     • Networks: ${environments}


### PR DESCRIPTION
### Add installation count to agent details log output in the `logAgentDetails` function
The `logAgentDetails` function in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/162/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) now fetches installation data using `firstClient.preferences.inboxState()` and displays the count of installations in the console output alongside existing client information.

#### 📍Where to Start
Start with the `logAgentDetails` function in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/162/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1).

----

_[Macroscope](https://app.macroscope.com) summarized 8cd8ad2._