### PR TITLE
Refactor client creation for clarity in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,22 +90,19 @@ import { Client, type XmtpEnv, type Signer } from "@xmtp/node-sdk";
 const encryptionKey: Uint8Array = ...;
 const signer: Signer = ...;
 const env: XmtpEnv = "dev";
-
-async function main() {
-  const client = await Client.create(signer, encryptionKey, { env });
-  await client.conversations.sync();
-  const stream = await client.conversations.streamAllMessages();
-  for await (const message of  stream) {
-    // ignore messages from the agent
-   if (message?.senderInboxId === client.inboxId ) {
-      continue;
-    }
-    const conversation = await client.conversations.getConversationById(message.conversationId);
-    // send a message from the agent
-    await conversation.send("gm");
+// create the client
+const client = await Client.create(signer, encryptionKey, { env });
+await client.conversations.sync();
+const stream = await client.conversations.streamAllMessages();
+for await (const message of  stream) {
+  // ignore messages from the agent
+  if (message?.senderInboxId === client.inboxId ) {
+    continue;
   }
+  const conversation = await client.conversations.getConversationById(message.conversationId);
+  // send a message from the agent
+  await conversation.send("gm");
 }
-main().catch(console.error);
 ```
 
 ### Getting the address of a user


### PR DESCRIPTION
### Remove async function wrapper from XMTP client example code in README documentation for clarity
The code example in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/163/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) removes the `main()` async function wrapper and associated `.catch(console.error)` error handling, presenting the XMTP client creation and message handling code directly without the function declaration structure.

#### 📍Where to Start
Start with the code example section in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/163/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) where the XMTP client creation code has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized e55f273._