### PR TITLE
Update README to clarify XMTP listener setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,22 +90,19 @@ import { Client, type XmtpEnv, type Signer } from "@xmtp/node-sdk";
 const encryptionKey: Uint8Array = ...;
 const signer: Signer = ...;
 const env: XmtpEnv = "dev";
-
-async function main() {
-  const client = await Client.create(signer, encryptionKey, { env });
-  await client.conversations.sync();
-  const stream = await client.conversations.streamAllMessages();
-  for await (const message of  stream) {
-    // ignore messages from the agent
-   if (message?.senderInboxId === client.inboxId ) {
-      continue;
-    }
-    const conversation = await client.conversations.getConversationById(message.conversationId);
-    // send a message from the agent
-    await conversation.send("gm");
+// create the client
+const client = await Client.create(signer, encryptionKey, { env });
+await client.conversations.sync();
+const stream = await client.conversations.streamAllMessages();
+for await (const message of  stream) {
+  // ignore messages from the agent
+  if (message?.senderInboxId === client.inboxId ) {
+    continue;
   }
+  const conversation = await client.conversations.getConversationById(message.conversationId);
+  // send a message from the agent
+  await conversation.send("gm");
 }
-main().catch(console.error);
 ```
 
 ### Getting the address of a user

--- a/README.md
+++ b/README.md
@@ -86,14 +86,18 @@ These are the steps to initialize the XMTP listener and send messages.
 ```tsx
 // import the xmtp sdk
 import { Client, type XmtpEnv, type Signer } from "@xmtp/node-sdk";
+
 // encryption key, must be consistent across runs
 const encryptionKey: Uint8Array = ...;
 const signer: Signer = ...;
 const env: XmtpEnv = "dev";
+
 // create the client
 const client = await Client.create(signer, encryptionKey, { env });
 await client.conversations.sync();
 const stream = await client.conversations.streamAllMessages();
+
+// listen to all messages
 for await (const message of  stream) {
   // ignore messages from the agent
   if (message?.senderInboxId === client.inboxId ) {


### PR DESCRIPTION
### Restructure XMTP listener setup code example in README to clarify setup steps by removing function wrapper and adding organizational comments
The code example in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/164/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) removes the `main()` function wrapper and associated error handling, presenting the client creation and message handling as a flat sequence. Adds organizational comments "// create the client" and "// listen to all messages" to better structure the code sections.

#### 📍Where to Start
Start with the code example section in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/164/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) where the XMTP client setup and message handling is demonstrated.

----

_[Macroscope](https://app.macroscope.com) summarized e2c362d._