### PR TITLE
Improve client message synchronization in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ const env: XmtpEnv = "dev";
 
 // create the client
 const client = await Client.create(signer, {encryptionKey, env });
+// sync the client to get the latest messages
 await client.conversations.sync();
-const stream = await client.conversations.streamAllMessages();
 
 // listen to all messages
+const stream = await client.conversations.streamAllMessages();
 for await (const message of  stream) {
   // ignore messages from the agent
   if (message?.senderInboxId === client.inboxId ) continue;


### PR DESCRIPTION
### Improve client message synchronization documentation and reorder code example in README
The code example in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/168/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) adds a comment explaining the purpose of `client.conversations.sync()` and reorders the `client.conversations.streamAllMessages()` call to appear after the sync operation comment.

#### 📍Where to Start
Start with the code example section in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/168/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

----

_[Macroscope](https://app.macroscope.com) summarized a308f3b._