### PR TITLE
Add xmtp-group-welcome example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ const addressFromInboxId = inboxState[0].identifiers[0].identifier;
 - [xmtp-queue-dual-client](/examples/xmtp-queue-dual-client/): Agent that uses two clients to send and receive messages
 - [xmtp-multiple-workers](/examples/xmtp-multiple-workers/): Agent that uses multiple workers to send and receive messages
 - [xmtp-stream-restart](/examples/xmtp-stream-restart/): Agent that restarts the stream when it fails
+- [xmtp-group-welcome](/examples/xmtp-group-welcome/): Agent that sends a welcome message when its added and to new members of a group
 
-This examples are outside of this monorepo and showcase how to use and deploy XMTP in different environments.
+These examples are outside of this monorepo and showcase how to use and deploy XMTP in different environments.
 
 - [gm-bot](https://github.com/xmtp/gm-bot): Simple standalone agent that replies to all messages with "gm"
 - [xmtp-mini-app-example](https://github.com/ephemeraHQ/xmtp-mini-app): A simple mini app that interacts with a group


### PR DESCRIPTION
### Add xmtp-group-welcome example to README.md documentation
Updates the [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/171/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) file by adding a new `xmtp-group-welcome` example to the examples list and corrects a grammatical error changing "This examples" to "These examples".

#### 📍Where to Start
Start with the examples section in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/171/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) where the new `xmtp-group-welcome` example has been added.

----

_[Macroscope](https://app.macroscope.com) summarized ed9835d._