### PR TITLE
Refactor message filtering for clarity and maintainability

### DIFF
--- a/examples/xmtp-attachment-content-type/index.ts
+++ b/examples/xmtp-attachment-content-type/index.ts
@@ -81,10 +81,13 @@ async function main() {
   const stream = await client.conversations.streamAllMessages();
 
   for await (const message of stream) {
-    if (
-      message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase() ||
-      message?.contentType?.typeId !== "text"
-    ) {
+    /* Ignore messages from the same agent or non-text messages */
+    if (message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+
+    /* Ignore non-text messages */
+    if (message?.contentType?.typeId !== "text") {
       continue;
     }
 

--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -57,10 +57,12 @@ async function main() {
 
   for await (const message of stream) {
     /* Ignore messages from the same agent or non-text messages */
-    if (
-      message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase() ||
-      message?.contentType?.typeId !== "text"
-    ) {
+    if (message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+
+    /* Ignore non-text messages */
+    if (message?.contentType?.typeId !== "text") {
       continue;
     }
 

--- a/examples/xmtp-nft-gated-group/index.ts
+++ b/examples/xmtp-nft-gated-group/index.ts
@@ -49,10 +49,12 @@ async function main() {
 
   for await (const message of stream) {
     /* Ignore messages from the same agent or non-text messages */
-    if (
-      message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase() ||
-      message?.contentType?.typeId !== "text"
-    ) {
+    if (message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+
+    /* Ignore non-text messages */
+    if (message?.contentType?.typeId !== "text") {
       continue;
     }
 

--- a/examples/xmtp-queue-dual-client/index.ts
+++ b/examples/xmtp-queue-dual-client/index.ts
@@ -118,14 +118,17 @@ async function setupMessageStream(client: Client): Promise<void> {
 
     // Process incoming messages
     for await (const message of stream) {
-      // Ignore messages from self or non-text messages
+      /* Ignore messages from the same agent or non-text messages */
       if (
-        message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase() ||
-        message?.contentType?.typeId !== "text"
+        message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()
       ) {
         continue;
       }
 
+      /* Ignore non-text messages */
+      if (message?.contentType?.typeId !== "text") {
+        continue;
+      }
       const content = message.content as string;
       console.log(
         `Received: "${content}" in conversation ${message.conversationId}`,

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -48,10 +48,13 @@ const main = async () => {
   const stream = await client.conversations.streamAllMessages();
 
   for await (const message of stream) {
-    if (
-      message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase() ||
-      message?.contentType?.typeId !== "text"
-    ) {
+    /* Ignore messages from the same agent or non-text messages */
+    if (message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+
+    /* Ignore non-text messages */
+    if (message?.contentType?.typeId !== "text") {
       continue;
     }
 

--- a/examples/xmtp-transactions/index.ts
+++ b/examples/xmtp-transactions/index.ts
@@ -49,10 +49,12 @@ async function main() {
 
   for await (const message of stream) {
     /* Ignore messages from the same agent or non-text messages */
-    if (
-      message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase() ||
-      message?.contentType?.typeId !== "text"
-    ) {
+    if (message?.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+
+    /* Ignore non-text messages */
+    if (message?.contentType?.typeId !== "text") {
       continue;
     }
 

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -93,6 +93,7 @@ export const logAgentDetails = async (
   for (const [address, clientGroup] of Object.entries(clientsByAddress)) {
     const firstClient = clientGroup[0];
     const inboxId = firstClient.inboxId;
+    const installationId = firstClient.installationId;
     const environments = clientGroup
       .map((c: Client) => c.options?.env ?? "dev")
       .join(", ");
@@ -112,10 +113,11 @@ export const logAgentDetails = async (
 
     console.log(`
     ✓ XMTP Client:
-    • Address: ${address}
-    • Installations: ${installations.installations.length}
-    • Conversations: ${conversations.length}
     • InboxId: ${inboxId}
+    • Address: ${address}
+    • Conversations: ${conversations.length}
+    • Installations: ${installations.installations.length}
+    • InstallationId: ${installationId}
     • Networks: ${environments}
     ${urls.map((url) => `• URL: ${url}`).join("\n")}`);
   }


### PR DESCRIPTION
### Refactor message filtering logic in XMTP example files by splitting compound conditional statements into separate checks for clarity and maintainability
Splits compound `if` conditions containing two checks (ignoring messages from the same agent and ignoring non-text messages) into separate `if` statements with individual `continue` statements across six XMTP example files. Adds explanatory comments to clarify the purpose of each filtering check. Additionally modifies the logging output in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/173/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) by extracting and displaying the `installationId`, reordering console output to show `inboxId` before `address`, and moving the installations count display after conversations count.

#### 📍Where to Start
Start with any of the XMTP example files such as [examples/xmtp-attachment-content-type/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/173/files#diff-679e655f285c5b82ee82cb31084d244b45c1805fae918c42dff5b0730093e5b6) to see the refactored message filtering logic, as the changes are identical across all example files.

----

_[Macroscope](https://app.macroscope.com) summarized f4d6b2d._