### PR TITLE
Update logAgentDetails to use inboxState directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ const addressFromInboxId = inboxState[0].identifiers[0].identifier;
 - [xmtp-gaia](/examples/xmtp-gaia/): Agent that uses a CDP for gassless USDC on base
 - [xmtp-smart-wallet](/examples/xmtp-smart-wallet/): Agent that uses a smart wallet to send messages
 - [xmtp-attachments](/examples/xmtp-attachments/): Agent that sends images
+- [xmtp-revoke-installations](/examples/xmtp-revoke-installations/): Script that revokes excess installations
 - [xmtp-queue-dual-client](/examples/xmtp-queue-dual-client/): Agent that uses two clients to send and receive messages
 - [xmtp-multiple-workers](/examples/xmtp-multiple-workers/): Agent that uses multiple workers to send and receive messages
 - [xmtp-group-welcome](/examples/xmtp-group-welcome/): Sends a welcome message when its added and to new members

--- a/examples/xmtp-revoke-installations/index.ts
+++ b/examples/xmtp-revoke-installations/index.ts
@@ -6,7 +6,7 @@ import {
 import { Client, type XmtpEnv } from "@xmtp/node-sdk";
 
 const INBOX_ID =
-  "e3f6b9e01dac4bb3c4c5d96f856151f69b73433b868c3f1239cc82e2b0270e8b";
+  "459e8174735cecc475d36f1bdf2c39bd1440ed25026440249e379cea18a76a8a";
 const MAX_INSTALLATIONS = 5;
 
 /* Get the wallet key associated to the public key of
@@ -29,11 +29,16 @@ async function main() {
   );
 
   const currentInstallations = inboxState[0].installations;
-  console.log(`Current installations: ${currentInstallations.length}`);
+  console.log(`✓ Current installations: ${currentInstallations.length}`);
 
   // Only revoke if we're at or over the limit (accounting for new installation)
   if (currentInstallations.length >= MAX_INSTALLATIONS) {
+    // Calculate how many to revoke: current count - max allowed + 1 (for the new installation we're about to create)
+    // Example: 200 current - 5 max + 1 new = 196 to revoke, leaving 4 + 1 new = 5 total
     const excessCount = currentInstallations.length - MAX_INSTALLATIONS + 1;
+
+    // Revoke the oldest installations first (slice from beginning of array)
+    // This preserves the most recent installations which are likely still in use
     const installationsToRevoke = currentInstallations
       .slice(0, excessCount)
       .map((installation) => installation.bytes);
@@ -50,6 +55,7 @@ async function main() {
     console.log(`✓ Revoked ${excessCount} installations`);
   }
 
+  // Create new client (this adds a new installation)
   const client = await Client.create(signer, {
     dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -109,14 +109,15 @@ export const logAgentDetails = async (
     const urls = [`http://xmtp.chat/dm/${address}`];
 
     const conversations = await firstClient.conversations.list();
-    const installations = await firstClient.preferences.inboxState();
+    const inboxState = await firstClient.preferences.inboxState();
 
+    console.log(inboxState);
     console.log(`
     ✓ XMTP Client:
     • InboxId: ${inboxId}
     • Address: ${address}
     • Conversations: ${conversations.length}
-    • Installations: ${installations.installations.length}
+    • Installations: ${inboxState.installations.length}
     • InstallationId: ${installationId}
     • Networks: ${environments}
     ${urls.map((url) => `• URL: ${url}`).join("\n")}`);


### PR DESCRIPTION
### Update logAgentDetails function to use inboxState variable directly instead of installations variable when accessing inbox state data
- Improves installation revocation logic in [examples/xmtp-revoke-installations/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/178/files#diff-2919fbb7c721fa8f464da540411da245f51e05684231277be5147033de20af17) to selectively revoke only the oldest installations when over the limit, calculating the exact number to revoke based on current count and maximum allowed installations
- Renames variable from `installations` to `inboxState` in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/178/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) `logAgentDetails` function and adds logging of the complete inboxState object
- Adds documentation for the new xmtp-revoke-installations example script in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/178/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

#### 📍Where to Start
Start with the `logAgentDetails` function in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/178/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to understand the variable naming change from `installations` to `inboxState`.

----

_[Macroscope](https://app.macroscope.com) summarized 3fdfcff._