### PR TITLE
Refactor message handling to skip non-relevant cases

### DIFF
--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -69,6 +69,7 @@ async function main() {
           return;
         }
 
+        //Getting the address from the inbox id
         const inboxState = await client.preferences.inboxStateFromInboxIds([
           message.senderInboxId,
         ]);

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -4,7 +4,7 @@ import {
   logAgentDetails,
   validateEnvironment,
 } from "@helpers/client";
-import { Client, type XmtpEnv } from "@xmtp/node-sdk";
+import { Client, Group, type XmtpEnv } from "@xmtp/node-sdk";
 
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
@@ -43,11 +43,14 @@ async function main() {
       }
 
       void (async () => {
+        // Skip if the message is from the agent
         if (
-          message.senderInboxId.toLowerCase() ===
-            client.inboxId.toLowerCase() ||
-          message.contentType?.typeId !== "text"
+          message.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()
         ) {
+          return;
+        }
+        // Skip if the message is not a text message
+        if (message.contentType?.typeId !== "text") {
           return;
         }
 
@@ -57,6 +60,12 @@ async function main() {
 
         if (!conversation) {
           console.log("Unable to find conversation, skipping");
+          return;
+        }
+
+        // Skip if the conversation is a group
+        if (conversation instanceof Group) {
+          console.log("Conversation is a group, skipping");
           return;
         }
 


### PR DESCRIPTION
### Skip group conversations and restructure message filtering conditions in XMTP message handling to exclude non-relevant cases
The message handling logic in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/183/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9) adds a new check to skip group conversations by importing the `Group` type and checking if the conversation instance is of type `Group`. The existing message filtering conditions are restructured into separate conditional blocks that check for messages from the agent itself and non-text messages independently for improved readability.

#### 📍Where to Start
Start with the message handling logic in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/183/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9) where the new group conversation check and restructured filtering conditions are implemented.

----

_[Macroscope](https://app.macroscope.com) summarized c3ade78._