### PR TITLE
Fix link to XMTP rules

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -1,5 +1,5 @@
 # Cursor rules
 
-> See [XMTP rules](/.cursor/rules/xmtp.md) for vibe coding agents and best practices.
+> See [XMTP rules](/.cursor/rules/xmtp.mdc) for vibe coding agents and best practices.
 
 > See [monorepo guidelines](/.cursor/rules/monorepo-guidelines.mdc) for working in this monorepo or [standalone guidelines](https://github.com/xmtp/gm-bot/blob/main/.cursor/rules/guidelines.mdc) if you wish to work on a standalone repo.


### PR DESCRIPTION
### Update XMTP rules document link file extension from .md to .mdc in README.md
Changes the file extension in the XMTP rules document link from `.md` to `.mdc` in [.cursor/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/188/files#diff-c97b2d176b8c1829957fd2a6eae94d16b8d74a0937e6fe670aaac658ce3f2e27). The link path is updated from `/.cursor/rules/xmtp.md` to `/.cursor/rules/xmtp.mdc`.

#### 📍Where to Start
Start with the link modification in [.cursor/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/188/files#diff-c97b2d176b8c1829957fd2a6eae94d16b8d74a0937e6fe670aaac658ce3f2e27).

----

_[Macroscope](https://app.macroscope.com) summarized 07a2e82._