### PR TITLE
Add configuration for inbox ID and max installations

### DIFF
--- a/examples/xmtp-revoke-installations/.env.example
+++ b/examples/xmtp-revoke-installations/.env.example
@@ -1,4 +1,5 @@
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
 XMTP_ENV=dev # local, dev, production
-
+INBOX_ID=... # inbox id to restart
+MAX_INSTALLATIONS=5 # max installations at protocol level

--- a/examples/xmtp-revoke-installations/README.md
+++ b/examples/xmtp-revoke-installations/README.md
@@ -28,6 +28,8 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 WALLET_KEY= # the private key of the wallet
 ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
+INBOX_ID= # the inbox id of the user
+MAX_INSTALLATIONS= # the maximum number of installations allowed
 ```
 
 You can generate random xmtp keys with the following command:
@@ -46,11 +48,9 @@ yarn gen:keys
 git clone https://github.com/ephemeraHQ/xmtp-agent-examples.git
 # go to the folder
 cd xmtp-agent-examples
-cd examples/xmtp-gm
+cd examples/xmtp-revoke-installations
 # install packages
 yarn
-# generate random xmtp keys (optional)
-yarn gen:keys
 # run the example
 yarn dev
 ```

--- a/examples/xmtp-revoke-installations/index.ts
+++ b/examples/xmtp-revoke-installations/index.ts
@@ -5,19 +5,17 @@ import {
 } from "@helpers/client";
 import { Client, type XmtpEnv } from "@xmtp/node-sdk";
 
-const INBOX_ID =
-  "459e8174735cecc475d36f1bdf2c39bd1440ed25026440249e379cea18a76a8a";
-const MAX_INSTALLATIONS = 5;
-
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
  * that stores your agent's messages */
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
-  "WALLET_KEY",
-  "ENCRYPTION_KEY",
-  "XMTP_ENV",
-]);
-
+const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV, INBOX_ID, MAX_INSTALLATIONS } =
+  validateEnvironment([
+    "WALLET_KEY",
+    "ENCRYPTION_KEY",
+    "XMTP_ENV",
+    "INBOX_ID",
+    "MAX_INSTALLATIONS",
+  ]);
 /* Create the signer using viem and parse the encryption key for the local db */
 const signer = createSigner(WALLET_KEY);
 const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
@@ -32,10 +30,11 @@ async function main() {
   console.log(`✓ Current installations: ${currentInstallations.length}`);
 
   // Only revoke if we're at or over the limit (accounting for new installation)
-  if (currentInstallations.length >= MAX_INSTALLATIONS) {
+  if (currentInstallations.length >= parseInt(MAX_INSTALLATIONS)) {
     // Calculate how many to revoke: current count - max allowed + 1 (for the new installation we're about to create)
     // Example: 200 current - 5 max + 1 new = 196 to revoke, leaving 4 + 1 new = 5 total
-    const excessCount = currentInstallations.length - MAX_INSTALLATIONS + 1;
+    const excessCount =
+      currentInstallations.length - parseInt(MAX_INSTALLATIONS) + 1;
 
     // Revoke the oldest installations first (slice from beginning of array)
     // This preserves the most recent installations which are likely still in use


### PR DESCRIPTION
### Replace hardcoded INBOX_ID and MAX_INSTALLATIONS constants with environment variables in xmtp-revoke-installations example
Replaces hardcoded constants with environment variables to make the xmtp-revoke-installations example configurable. The changes include:

- Removes hardcoded `INBOX_ID` and `MAX_INSTALLATIONS` constants from [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/190/files#diff-2919fbb7c721fa8f464da540411da245f51e05684231277be5147033de20af17)
- Adds `INBOX_ID` and `MAX_INSTALLATIONS` to required environment variables in `validateEnvironment` call
- Updates environment variable destructuring to include the new variables
- Modifies comparison logic to parse `MAX_INSTALLATIONS` as integer using `parseInt()`
- Updates [.env.example](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/190/files#diff-f2ea2b90821f2f55c096b9275e3c513d44bbb240f24c7f495e22e0fffd015ffe) to include the new environment variables
- Corrects directory path in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/190/files#diff-431cb850ee722a91824ebeae2c3ffe1884654d59aadf4fae253ce38a0cfec8e2) installation instructions

#### 📍Where to Start
Start with the `validateEnvironment` call and environment variable destructuring in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/190/files#diff-2919fbb7c721fa8f464da540411da245f51e05684231277be5147033de20af17) to see how the hardcoded constants were replaced with environment variables.

----

_[Macroscope](https://app.macroscope.com) summarized 4927bcd._