### PR TITLE
Track message count for received messages in example

### DIFF
--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -19,6 +19,9 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
 const signer = createSigner(WALLET_KEY);
 const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
+// Message counter
+let messageCount = 0;
+
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
@@ -53,6 +56,10 @@ async function main() {
         if (message.contentType?.typeId !== "text") {
           return;
         }
+
+        // Increment message counter for valid messages
+        messageCount++;
+        console.log(`📩 Message received! Total count: ${messageCount}`);
 
         const conversation = await client.conversations.getConversationById(
           message.conversationId,

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -19,9 +19,6 @@ const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
 const signer = createSigner(WALLET_KEY);
 const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 
-// Message counter
-let messageCount = 0;
-
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -54,9 +54,6 @@ async function main() {
           return;
         }
 
-        // Increment message counter for valid messages
-        messageCount++;
-
         const conversation = await client.conversations.getConversationById(
           message.conversationId,
         );

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -59,7 +59,6 @@ async function main() {
 
         // Increment message counter for valid messages
         messageCount++;
-        console.log(`📩 Message received! Total count: ${messageCount}`);
 
         const conversation = await client.conversations.getConversationById(
           message.conversationId,

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "typecheck": "tsc"
   },
   "resolutions": {
-    "@xmtp/node-sdk": "3.1.1"
+    "@xmtp/node-sdk": "3.1.2"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "3.1.1",
+    "@xmtp/node-sdk": "3.1.2",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,22 +2121,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:1.2.7":
-  version: 1.2.7
-  resolution: "@xmtp/node-bindings@npm:1.2.7"
-  checksum: 10/b077e651c0dde2b3dbc1d259ca876fecf995bb984e39c4d644b94c87f4d0f6b8b743dfc0813f7a485f00936ba04e88cd66444bab94feadfc06927111991b865a
+"@xmtp/node-bindings@npm:1.2.8":
+  version: 1.2.8
+  resolution: "@xmtp/node-bindings@npm:1.2.8"
+  checksum: 10/80c34b8868c0ae7dbd4986398f77a7c4453ec917cbcab2e45424b837f78482714c4a8100049824414403121b8816c0e8d2f2696f0db94b42322f61fcdc010b64
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:3.1.1":
-  version: 3.1.1
-  resolution: "@xmtp/node-sdk@npm:3.1.1"
+"@xmtp/node-sdk@npm:3.1.2":
+  version: 3.1.2
+  resolution: "@xmtp/node-sdk@npm:3.1.2"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.7"
-  checksum: 10/d262eec49e3ef79104bd15c13c89943c06cbf151a1997806710d14b06bb90fe4f3320856e1549e1e0ddcc9060e18d8caf807acd45138a3a9aad1fb77a9fd3ce1
+    "@xmtp/node-bindings": "npm:1.2.8"
+  checksum: 10/5289180b18917609113822cc27ebde7d8088ef7a5f3349187fc2e2d5311b7609f5c5fdc2f28806c32e06fb24b072ca9e611e0126f375b0bc4ec29e6ca1b91251
   languageName: node
   linkType: hard
 
@@ -5744,7 +5744,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:3.1.1"
+    "@xmtp/node-sdk": "npm:3.1.2"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"


### PR DESCRIPTION
### Update @xmtp/node-sdk dependency from version 3.1.1 to 3.1.2 to track message count for received messages in example
Updates the `@xmtp/node-sdk` package dependency from version 3.1.1 to 3.1.2 in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/192/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and regenerates the corresponding lock file entries in [yarn.lock](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/192/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

#### 📍Where to Start
Start with the dependency version changes in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/192/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized 4b826fb._