### PR TITLE
Polished titles

### DIFF
--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -1,8 +1,9 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
+
 # Writing XMTP Agents
 
 You're an expert in writing TypeScript with Node.js. Generate **high-quality XMTP Agents** that adhere to the following best practices:
@@ -390,7 +391,7 @@ async function main() {
 main().catch(console.error);
 ```
 
-## XMTP Helper Functions
+## Helper Functions
 
 ```typescript
 import { getRandomValues } from "node:crypto";
@@ -460,7 +461,7 @@ export const getEncryptionKeyFromHex = (hex: string) => {
 };
 ```
 
-## XMTP Packages Reference
+## Packages Reference
 
 ```tsx
 // Client Class
@@ -494,7 +495,7 @@ for await (const message of stream) {
 }
 ```
 
-## XMTP Identifiers Reference
+## Identifiers Reference
 
 When working with XMTP, you'll encounter several types of identifiers:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# XMTP code of conduct
+#code of conduct
 
 This code of conduct applies within all XMTP community spaces, virtual and physical, and also applies when an individual is officially representing the XMTP community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-#code of conduct
+# code of conduct
 
 This code of conduct applies within all XMTP community spaces, virtual and physical, and also applies when an individual is officially representing the XMTP community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XMTP agent examples
+#agent examples
 
 This repository provides examples of agents that use the [XMTP](https://docs.xmtp.org/) network. These agents are built with the [XMTP Node SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#agent examples
+# XMTP agent examples
 
 This repository provides examples of agents that use the [XMTP](https://docs.xmtp.org/) network. These agents are built with the [XMTP Node SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk).
 

--- a/examples/xmtp-attachments/README.md
+++ b/examples/xmtp-attachments/README.md
@@ -1,4 +1,4 @@
-# Attachments (image)
+# Image attachment example
 
 This agent replies with an image attachment.
 

--- a/examples/xmtp-coinbase-agentkit/README.md
+++ b/examples/xmtp-coinbase-agentkit/README.md
@@ -1,4 +1,4 @@
-# CDP AgentKit LangChain
+# CDP agentKit langchain example
 
 This example demonstrates an agent setup on XMTP Network with access to the full set of CDP AgentKit actions.
 

--- a/examples/xmtp-gaia/.env.example
+++ b/examples/xmtp-gaia/.env.example
@@ -1,4 +1,4 @@
-# XMTP 
+#
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet

--- a/examples/xmtp-gaia/.env.example
+++ b/examples/xmtp-gaia/.env.example
@@ -1,4 +1,3 @@
-#
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet

--- a/examples/xmtp-gm/README.md
+++ b/examples/xmtp-gm/README.md
@@ -1,4 +1,4 @@
-# GM agent
+# GM example
 
 This agent replies `gm`
 

--- a/examples/xmtp-gpt/.env.example
+++ b/examples/xmtp-gpt/.env.example
@@ -1,4 +1,4 @@
-# XMTP 
+#
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet

--- a/examples/xmtp-gpt/.env.example
+++ b/examples/xmtp-gpt/.env.example
@@ -1,4 +1,3 @@
-#
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet

--- a/examples/xmtp-multiple-workers/README.md
+++ b/examples/xmtp-multiple-workers/README.md
@@ -20,15 +20,15 @@ To run your XMTP agents, you must create a `.env` file with the following variab
 ```bash
 XMTP_ENV=dev # local, dev, production
 
-# XMTP keys for agent 1
+#keys for agent 1
 WALLET_KEY_AGENT1= # the private key of the wallet
 ENCRYPTION_KEY_AGENT1= # encryption key for local db encryption
 
-# XMTP keys for agent 2
+#keys for agent 2
 WALLET_KEY_AGENT2= # the private key of the wallet
 ENCRYPTION_KEY_AGENT2= # encryption key for local db encryption
 
-# XMTP keys for agent 3
+#keys for agent 3
 WALLET_KEY_AGENT3= # the private key of the wallet
 ENCRYPTION_KEY_AGENT3= # encryption key for local db encryption
 ```

--- a/examples/xmtp-multiple-workers/README.md
+++ b/examples/xmtp-multiple-workers/README.md
@@ -20,15 +20,15 @@ To run your XMTP agents, you must create a `.env` file with the following variab
 ```bash
 XMTP_ENV=dev # local, dev, production
 
-#keys for agent 1
+# keys for agent 1
 WALLET_KEY_AGENT1= # the private key of the wallet
 ENCRYPTION_KEY_AGENT1= # encryption key for local db encryption
 
-#keys for agent 2
+# keys for agent 2
 WALLET_KEY_AGENT2= # the private key of the wallet
 ENCRYPTION_KEY_AGENT2= # encryption key for local db encryption
 
-#keys for agent 3
+# keys for agent 3
 WALLET_KEY_AGENT3= # the private key of the wallet
 ENCRYPTION_KEY_AGENT3= # encryption key for local db encryption
 ```

--- a/examples/xmtp-nft-gated-group/.env.example
+++ b/examples/xmtp-nft-gated-group/.env.example
@@ -1,4 +1,4 @@
-# XMTP 
+#
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet

--- a/examples/xmtp-nft-gated-group/.env.example
+++ b/examples/xmtp-nft-gated-group/.env.example
@@ -1,4 +1,3 @@
-#
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
 ENCRYPTION_KEY= # the encryption key for the wallet

--- a/examples/xmtp-nft-gated-group/README.md
+++ b/examples/xmtp-nft-gated-group/README.md
@@ -1,4 +1,4 @@
-# Building a gated group with NFT verification
+# NFT gated group example
 
 To create a gated group chat using XMTP, you will need an admin agent within the group to manage member additions and removals. The admin agent will create the group, assign you as the admin, and then verify NFT ownership before adding new members.
 

--- a/examples/xmtp-queue-dual-client/README.md
+++ b/examples/xmtp-queue-dual-client/README.md
@@ -1,4 +1,4 @@
-#Queue Dual Client Agent
+# Dual client example
 
 This agent demonstrates the use of dual clients in XMTP.
 

--- a/examples/xmtp-queue-dual-client/README.md
+++ b/examples/xmtp-queue-dual-client/README.md
@@ -1,4 +1,4 @@
-# XMTP Queue Dual Client Agent
+#Queue Dual Client Agent
 
 This agent demonstrates the use of dual clients in XMTP.
 

--- a/examples/xmtp-revoke-installations/README.md
+++ b/examples/xmtp-revoke-installations/README.md
@@ -1,4 +1,4 @@
-# Revoking installations
+# Revoking installations example
 
 An installation in XMTP refers to a unique instance of an app (like on a device ) that accesses a user’s inbox. Each installation gets its own ID and is tracked separately, allowing users to manage which devices have access to their messages. Starting with node `2.2.0`, XMTP enforces a strict limit of `5` active installations per inbox. This is crucial to prevent excessive group sizes and avoid hitting the 256 inbox update limit, which would force users to rotate their inbox and lose existing conversations.
 

--- a/examples/xmtp-skills/README.md
+++ b/examples/xmtp-skills/README.md
@@ -1,4 +1,4 @@
-#Skills
+# Skills
 
 This example shows how to build XMTP agents using a helper pattern that separates XMTP logic from business logic.
 

--- a/examples/xmtp-skills/README.md
+++ b/examples/xmtp-skills/README.md
@@ -1,4 +1,4 @@
-# XMTP Skills
+#Skills
 
 This example shows how to build XMTP agents using a helper pattern that separates XMTP logic from business logic.
 

--- a/examples/xmtp-skills/README.md
+++ b/examples/xmtp-skills/README.md
@@ -1,4 +1,4 @@
-# Skills
+# Skills example
 
 This example shows how to build XMTP agents using a helper pattern that separates XMTP logic from business logic.
 

--- a/examples/xmtp-smart-wallet/README.md
+++ b/examples/xmtp-smart-wallet/README.md
@@ -1,4 +1,4 @@
-# CDP Smart Contract Wallet
+# CDP smart contract wallet example
 
 This example demonstrates an agent setup on XMTP Network with access to the full set of CDP Smart Contract Wallets.
 

--- a/examples/xmtp-stream-restart/README.md
+++ b/examples/xmtp-stream-restart/README.md
@@ -1,4 +1,4 @@
-# XMTP Stream Restart
+#Stream Restart
 
 All streaming methods accept a callback as the last argument that will be called when the stream fails. Use this callback to restart the stream.
 

--- a/examples/xmtp-stream-restart/README.md
+++ b/examples/xmtp-stream-restart/README.md
@@ -1,4 +1,4 @@
-#Stream Restart
+# Stream restart example
 
 All streaming methods accept a callback as the last argument that will be called when the stream fails. Use this callback to restart the stream.
 

--- a/scripts/generateKeys.ts
+++ b/scripts/generateKeys.ts
@@ -38,7 +38,7 @@ try {
 // Check if XMTP_ENV is already set
 const xmtpEnvExists = existingEnv.includes("XMTP_ENV=");
 
-const envContent = `# XMTP keys for ${exampleName}
+const envContent = `#keys for ${exampleName}
 WALLET_KEY=${walletKey}
 ENCRYPTION_KEY=${encryptionKeyHex}
 ${!xmtpEnvExists ? "XMTP_ENV=dev\n" : ""}# public key is ${publicKey}

--- a/scripts/generateKeys.ts
+++ b/scripts/generateKeys.ts
@@ -38,7 +38,7 @@ try {
 // Check if XMTP_ENV is already set
 const xmtpEnvExists = existingEnv.includes("XMTP_ENV=");
 
-const envContent = `#keys for ${exampleName}
+const envContent = `# keys for ${exampleName}
 WALLET_KEY=${walletKey}
 ENCRYPTION_KEY=${encryptionKeyHex}
 ${!xmtpEnvExists ? "XMTP_ENV=dev\n" : ""}# public key is ${publicKey}


### PR DESCRIPTION
### Remove unnecessary comments from example environment files and update documentation titles
This pull request removes unnecessary comments from environment files and updates documentation titles across multiple example directories and configuration files:

- Removes `# XMTP` comment lines from environment example files in [examples/xmtp-gaia/.env.example](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/194/files#diff-55860adbebb172fba47fd836bd4e6fe342957cd61d8ab62cf343151eba16e000), [examples/xmtp-gpt/.env.example](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/194/files#diff-381eaa65a8d8d6fc3d1ee893fe3224541b4676bfbd61c90f043f3872fda8443e), and [examples/xmtp-nft-gated-group/.env.example](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/194/files#diff-57e9c7c1aeb0fde290579833e60db1dbbe4a922852889aee822397821289298f)
- Updates README titles across example directories to use more concise naming conventions, removing redundant prefixes
- Modifies section titles in [.cursor/rules/xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/194/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20) by removing `XMTP` prefixes from helper functions, packages reference, and identifiers reference sections
- Updates the comment template in [scripts/generateKeys.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/194/files#diff-cb5089ecceb276561844eb8c44432b03a43269e31c82a6bb97059cb4c3df9875) to remove `XMTP` prefix from generated environment file comments

#### 📍Where to Start
Start with the environment example files such as [examples/xmtp-gaia/.env.example](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/194/files#diff-55860adbebb172fba47fd836bd4e6fe342957cd61d8ab62cf343151eba16e000) to see the comment removal pattern, then review the README title changes across the example directories.

----

_[Macroscope](https://app.macroscope.com) summarized 14d35b3._