### PR TITLE
Add logging level to environment validation for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ yarn gen:keys
 You can revoke old installations by running:
 
 ```bash
-yarn revoke <inbox-id> <revoke-count>
+yarn revoke <inbox-id> <installations-to-save>
 ```
 
 ### Run an example agent

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -86,16 +86,6 @@ async function main() {
 
   // Start the message stream
   messageStream();
-
-  // await client.conversations.syncAll();
-  // const dm = await client.conversations.newDm(
-  //   "ed78558739ee53e9455cc76e86c70fee070b342e06ee794d8c4e0859f0a07f98",
-  // );
-  // const debugStatus = (await dm.debugInfo()).maybeForked;
-  // console.log("Debug status:", debugStatus);
-  // console.log("Id:", dm.id);
-  // await dm.sync();
-  // await dm.send("gm" + dm.id);
 }
 
 main().catch(console.error);

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -4,16 +4,18 @@ import {
   logAgentDetails,
   validateEnvironment,
 } from "@helpers/client";
-import { Client, Group, type XmtpEnv } from "@xmtp/node-sdk";
+import { Client, Group, type LogLevel, type XmtpEnv } from "@xmtp/node-sdk";
 
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
  * that stores your agent's messages */
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
-  "WALLET_KEY",
-  "ENCRYPTION_KEY",
-  "XMTP_ENV",
-]);
+const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV, LOGGING_LEVEL } =
+  validateEnvironment([
+    "WALLET_KEY",
+    "ENCRYPTION_KEY",
+    "XMTP_ENV",
+    "LOGGING_LEVEL",
+  ]);
 
 /* Create the signer using viem and parse the encryption key for the local db */
 const signer = createSigner(WALLET_KEY);
@@ -23,6 +25,7 @@ async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
     env: XMTP_ENV as XmtpEnv,
+    loggingLevel: LOGGING_LEVEL as LogLevel,
   });
   void logAgentDetails(client);
 
@@ -68,6 +71,7 @@ async function main() {
           console.log("Conversation is a group, skipping");
           return;
         }
+        console.log("Conversation with ", message.senderInboxId);
 
         //Getting the address from the inbox id
         const inboxState = await client.preferences.inboxStateFromInboxIds([
@@ -82,6 +86,16 @@ async function main() {
 
   // Start the message stream
   messageStream();
+
+  await client.conversations.syncAll();
+  const dm = await client.conversations.newDm(
+    "ed78558739ee53e9455cc76e86c70fee070b342e06ee794d8c4e0859f0a07f98",
+  );
+  const debugStatus = (await dm.debugInfo()).maybeForked;
+  console.log("Debug status:", debugStatus);
+  console.log("Id:", dm.id);
+  await dm.sync();
+  await dm.send("gm" + dm.id);
 }
 
 main().catch(console.error);

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -87,15 +87,15 @@ async function main() {
   // Start the message stream
   messageStream();
 
-  await client.conversations.syncAll();
-  const dm = await client.conversations.newDm(
-    "ed78558739ee53e9455cc76e86c70fee070b342e06ee794d8c4e0859f0a07f98",
-  );
-  const debugStatus = (await dm.debugInfo()).maybeForked;
-  console.log("Debug status:", debugStatus);
-  console.log("Id:", dm.id);
-  await dm.sync();
-  await dm.send("gm" + dm.id);
+  // await client.conversations.syncAll();
+  // const dm = await client.conversations.newDm(
+  //   "ed78558739ee53e9455cc76e86c70fee070b342e06ee794d8c4e0859f0a07f98",
+  // );
+  // const debugStatus = (await dm.debugInfo()).maybeForked;
+  // console.log("Debug status:", debugStatus);
+  // console.log("Id:", dm.id);
+  // await dm.sync();
+  // await dm.send("gm" + dm.id);
 }
 
 main().catch(console.error);

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -106,26 +106,25 @@ export const logAgentDetails = async (
         ╚═╝  ╚═╝╚═╝     ╚═╝   ╚═╝   ╚═╝     
       \x1b[0m`);
 
-    const urls = [`http://xmtp.chat/dm/${address}`];
-
     const conversations = await firstClient.conversations.list();
     const inboxState = await firstClient.preferences.inboxState();
-    const installationWarning =
-      inboxState.installations.length >= 4
-        ? `\n\x1b[38;2;252;76;52m⚠️ 5 max installations, run "yarn revoke <inbox-id> <installations-to-save>" to revoke the old installations.\x1b[0m \n
-        Example: yarn revoke ${inboxId} ${installationId}`
-        : "";
+
     console.log(`
     ✓ XMTP Client:
-    • InboxId: ${inboxId}
-    • Address: ${address}
-    • Conversations: ${conversations.length}
-    • Installations: ${inboxState.installations.length}
-    • InstallationId: ${installationId} 
-    • Networks: ${environments}
-    ${urls.map((url) => `• URL: ${url}`).join("\n")}`);
+      • InboxId: ${inboxId}
+      • Address: ${address}
+      • Conversations: ${conversations.length}
+      • Installations: ${inboxState.installations.length}
+      • InstallationId: ${installationId} source ~/.bashrc;pr_push
+      • Networks: ${environments}
+      • URL: https://xmtp.chat/dm/${address}`);
 
-    console.log(installationWarning);
+    if (inboxState.installations.length >= 4) {
+      console.log(
+        `\n\x1b[38;2;252;76;52m⚠️ 5 max installations, run "yarn revoke <inbox-id> <installations-to-save>" to revoke the old installations.\x1b[0m \n
+        Example: yarn revoke ${inboxId} ${installationId}`,
+      );
+    }
   }
 };
 export function validateEnvironment(vars: string[]): Record<string, string> {

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -121,8 +121,7 @@ export const logAgentDetails = async (
 
     if (inboxState.installations.length >= 4) {
       console.log(
-        `\n\x1b[38;2;252;76;52m⚠️ 5 max installations, run "yarn revoke <inbox-id> <installations-to-save>" to revoke the old installations.\x1b[0m \n
-        Example: yarn revoke ${inboxId} ${installationId}`,
+        `\n\x1b[33m⚠️  Warning: 5 max installations reached!\nRun "yarn revoke <inbox-id> <installations-to-save>" to revoke old installations.\nExample: yarn revoke ${inboxId} ${installationId}\x1b[0m\n`,
       );
     }
   }

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -112,17 +112,20 @@ export const logAgentDetails = async (
     const inboxState = await firstClient.preferences.inboxState();
     const installationWarning =
       inboxState.installations.length >= 4
-        ? `\n\t\x1b[38;2;252;76;52m⚠️ 5 max installations, run "yarn revoke <inbox-id> <revoke-count>" to revoke the old installations.\x1b[0m`
+        ? `\n\x1b[38;2;252;76;52m⚠️ 5 max installations, run "yarn revoke <inbox-id> <installations-to-save>" to revoke the old installations.\x1b[0m \n
+        Example: yarn revoke ${inboxId} ${installationId}`
         : "";
     console.log(`
     ✓ XMTP Client:
     • InboxId: ${inboxId}
     • Address: ${address}
     • Conversations: ${conversations.length}
-    • Installations: ${inboxState.installations.length} ${installationWarning}
+    • Installations: ${inboxState.installations.length}
     • InstallationId: ${installationId} 
     • Networks: ${environments}
     ${urls.map((url) => `• URL: ${url}`).join("\n")}`);
+
+    console.log(installationWarning);
   }
 };
 export function validateEnvironment(vars: string[]): Record<string, string> {

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -115,7 +115,7 @@ export const logAgentDetails = async (
       • Address: ${address}
       • Conversations: ${conversations.length}
       • Installations: ${inboxState.installations.length}
-      • InstallationId: ${installationId} source ~/.bashrc;pr_push
+      • InstallationId: ${installationId} 
       • Networks: ${environments}
       • URL: https://xmtp.chat/dm/${address}`);
 

--- a/scripts/revokeInstallations.ts
+++ b/scripts/revokeInstallations.ts
@@ -23,9 +23,6 @@ async function main() {
       "Usage: yarn revoke-installations <inbox-id> [installations-to-save]",
     );
     console.error(
-      "Example: yarn revoke-installations 743f3805fa9daaf879103bc26a2e79bb53db688088259c23cf18dcf1ea2aee64",
-    );
-    console.error(
       'Example: yarn revoke-installations 743f3805fa9daaf879103bc26a2e79bb53db688088259c23cf18dcf1ea2aee64 "current-installation-id,another-installation-id"',
     );
     process.exit(1);
@@ -205,6 +202,19 @@ async function main() {
       console.error(
         "To revoke current installation, explicitly specify which other installations to keep.",
       );
+      process.exit(1);
+    }
+
+    // Safety check: ensure at least 1 installation remains after revocation
+    const remainingInstallations =
+      currentInstallations.length - installationsToRevoke.length;
+    if (remainingInstallations === 0) {
+      console.error(
+        "Error: Cannot revoke all installations. At least 1 installation must remain.",
+      );
+      console.error("Current installations:", currentInstallations.length);
+      console.error("Installations to revoke:", installationsToRevoke.length);
+      console.error("Please specify at least 1 installation to keep.");
       process.exit(1);
     }
 

--- a/scripts/revokeInstallations.ts
+++ b/scripts/revokeInstallations.ts
@@ -107,12 +107,18 @@ async function main() {
     const currentInstallations = inboxState[0].installations;
     console.log(`✓ Current installations: ${currentInstallations.length}`);
 
-    // Filter out the current installation ID to protect it
-    const installationsToRevoke = currentInstallations.filter(
-      (installation) => {
-        const installationHex = Buffer.from(installation.bytes).toString("hex");
-        return installationHex !== currentInstallationId;
-      },
+    // If there's only 1 installation, it's the current one - don't revoke anything
+    if (currentInstallations.length === 1) {
+      console.log(
+        `✓ Only 1 installation found - this is the current one, nothing to revoke`,
+      );
+      return;
+    }
+
+    // Keep the latest installation (last in array) and revoke the rest
+    const installationsToRevoke = currentInstallations.slice(0, -1);
+    console.log(
+      `Available for revocation: ${installationsToRevoke.length} (keeping latest)`,
     );
 
     // Determine how many installations to revoke
@@ -143,6 +149,7 @@ async function main() {
     // Safety check: if no installations are available for revocation, don't proceed
     if (installationsToRevoke.length === 0) {
       console.log(`✓ Only current installation remains - nothing to revoke`);
+      console.log(`Current installation ID: ${currentInstallationId}`);
       return;
     }
 


### PR DESCRIPTION
### Add logging level configuration to XMTP client initialization and redesign installation revocation to use explicit installation selection
- Adds `LogLevel` type import and `LOGGING_LEVEL` environment variable validation to [examples/xmtp-gm/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/197/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9), configuring the `Client.create()` call with the logging level parameter
- Redesigns the installation revocation mechanism in [scripts/revokeInstallations.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/197/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c) from a count-based approach to explicit installation selection, changing the parameter from `revoke-count` to `installations-to-save` with validation for inbox ID format (64 hex characters) and installation ID format
- Updates the installation warning message in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/197/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) with yellow text color and concrete example command using actual inbox and installation IDs
- Updates documentation in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/197/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reflect the parameter name change from `<revoke-count>` to `<installations-to-save>` in the revoke command example

#### 📍Where to Start
Start with the `Client.create()` call in [examples/xmtp-gm/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/197/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9) to see how the logging level configuration is implemented, then review the redesigned revocation logic in [scripts/revokeInstallations.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/197/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c).

----

_[Macroscope](https://app.macroscope.com) summarized bbb34bf._