### PR TITLE
Improve installation limit warnings and revoke logic clarity

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -114,14 +114,14 @@ export const logAgentDetails = async (
       • InboxId: ${inboxId}
       • Address: ${address}
       • Conversations: ${conversations.length}
-      • Installations: ${inboxState.installations.length}
+      • Installations: ${inboxState.installations.length}/5
       • InstallationId: ${installationId} 
       • Networks: ${environments}
       • URL: https://xmtp.chat/dm/${address}`);
 
     if (inboxState.installations.length >= 4) {
       console.log(
-        `\n\x1b[33m⚠️  Warning: 5 max installations reached!\nRun "yarn revoke <inbox-id> <installations-to-save>" to revoke old installations.\nExample: yarn revoke ${inboxId} ${installationId}\x1b[0m\n`,
+        `\n\x1b[33m⚠️  Warning: 5 is the max number of installations\nRun "yarn revoke <inbox-id> <installations-to-save>" to revoke old installations.\nExample: yarn revoke ${inboxId} ${installationId}\x1b[0m\n`,
       );
     }
   }


### PR DESCRIPTION
### Modify installation count display format to show current installations out of maximum 5 and require explicit specification of installations to keep in revocation script
- Changes console log output in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/198/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to display installation count as `x/5` format and updates warning message text for maximum installation limit
- Modifies [scripts/revokeInstallations.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/198/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c) to require explicit specification of installations to keep instead of defaulting to current installation, removes encryption key dependency, and eliminates safety check preventing current installation revocation

#### 📍Where to Start
Start with the console log modifications in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/198/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to understand the display format changes, then review the behavioral changes in [scripts/revokeInstallations.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/198/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c).

----

_[Macroscope](https://app.macroscope.com) summarized f1cb7df._