### PR TITLE
Add note on retrieving values from terminal logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ yarn gen:keys
 You can revoke old installations by running:
 
 ```bash
+# you can get your values from terminal logs
 yarn revoke <inbox-id> <installations-to-save>
 ```
 


### PR DESCRIPTION
### Add note on retrieving values from terminal logs in README.md documentation
Adds a comment to [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/201/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) explaining that users can retrieve required values from terminal logs when revoking old installations.

#### 📍Where to Start
Start with the documentation changes in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/201/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

----

_[Macroscope](https://app.macroscope.com) summarized 5e785e5._