### PR TITLE
Update README and warning message for clarity on revokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can revoke old installations by running:
 
 ```bash
 # you can get your values from terminal logs
-yarn revoke <inbox-id> <installations-to-save>
+yarn revoke <inbox-id> <installations-to-exclude>
 ```
 
 ### Run an example agent

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -121,7 +121,7 @@ export const logAgentDetails = async (
 
     if (inboxState.installations.length >= 4) {
       console.log(
-        `\n\x1b[33m⚠️  Warning: 5 is the max number of installations\nRun "yarn revoke <inbox-id> <installations-to-save>" to revoke old installations.\nExample: yarn revoke ${inboxId} ${installationId}\x1b[0m\n`,
+        `\n\x1b[33m⚠️  Warning: 5 is the max number of installations\nRun "yarn revoke <inbox-id> <installations-to-exclude>" to revoke old installations.\nExample: yarn revoke ${inboxId} ${installationId}\x1b[0m\n`,
       );
     }
   }


### PR DESCRIPTION
### Correct parameter description from 'installations-to-save' to 'installations-to-exclude' in README documentation and warning message for revoke command
This pull request corrects the parameter description for the revoke command in both documentation and console output. The changes update references from `installations-to-save` to `installations-to-exclude` in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/202/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and the warning message in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/202/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to accurately reflect the parameter's function.

#### 📍Where to Start
Start with the parameter description changes in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/202/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to understand the documentation correction, then review the corresponding warning message update in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/202/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1).

----

_[Macroscope](https://app.macroscope.com) summarized a7127ed._