### PR TITLE
fix: import open ai keys

### DIFF
--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -32,6 +32,7 @@ const {
   CDP_API_KEY_NAME,
   CDP_API_KEY_PRIVATE_KEY,
   NETWORK_ID,
+  OPENAI_API_KEY,
 } = validateEnvironment([
   "WALLET_KEY",
   "ENCRYPTION_KEY",
@@ -39,6 +40,7 @@ const {
   "CDP_API_KEY_NAME",
   "CDP_API_KEY_PRIVATE_KEY",
   "NETWORK_ID",
+  "OPENAI_API_KEY",
 ]);
 
 // Storage constants
@@ -143,6 +145,7 @@ async function initializeAgent(
   try {
     const llm = new ChatOpenAI({
       model: "gpt-4.1-mini",
+      apiKey: OPENAI_API_KEY,
     });
 
     const storedWalletData = getWalletData(userId);
@@ -200,8 +203,8 @@ async function initializeAgent(
         IMPORTANT:
         Your default network is Base Sepolia testnet. Your main and only token for transactions is USDC. Token address is 0x036CbD53842c5426634e7929541eC2318f3dCF7e. USDC is gasless on Base.
 
-        
-        Be concise, helpful, and security-focused in all your interactions. You can only perform payment and wallet-related tasks. For other requests, politely explain that you're 
+
+        Be concise, helpful, and security-focused in all your interactions. You can only perform payment and wallet-related tasks. For other requests, politely explain that you're
         specialized in processing payments and can't assist with other tasks.
       `,
     });


### PR DESCRIPTION
### Fix OpenAI API key configuration in XMTP Coinbase agent initialization
This change adds OpenAI API key configuration to the XMTP Coinbase agent by including `OPENAI_API_KEY` as a required environment variable and passing it to the `ChatOpenAI` constructor. The modification ensures the agent can authenticate with OpenAI's API services during LLM initialization in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/204/files#diff-b7bfbea16a422f169ef1ed3b4d8a2ce445a4e156099da3c36089bf91b538e752).

#### 📍Where to Start
Start with the environment variable destructuring and validation section in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/204/files#diff-b7bfbea16a422f169ef1ed3b4d8a2ce445a4e156099da3c36089bf91b538e752), then review the `ChatOpenAI` initialization where the API key is now configured.

----

_[Macroscope](https://app.macroscope.com) summarized 7baed6b._