### PR TITLE
Prompt user confirmation before revoking installations

### DIFF
--- a/scripts/revokeInstallations.ts
+++ b/scripts/revokeInstallations.ts
@@ -158,18 +158,34 @@ async function main() {
         process.exit(1);
       }
     } else {
-      // Require explicit specification of installations to keep
-      console.error(
-        "Error: No installations specified to keep. Please provide installation IDs to keep.",
+      // No installations specified - ask for confirmation to revoke all except current
+      console.log("\n⚠️  No installations specified to keep.");
+      console.log("Available installation IDs:");
+      currentInstallations.forEach((inst, index) => {
+        console.log(`  ${index + 1}. ${inst.id}`);
+      });
+
+      console.log(
+        `\nThis will revoke ALL ${currentInstallations.length - 1} installations except one (which will be kept as the current installation).`,
       );
-      console.error(
-        "Available installation IDs:",
-        currentInstallations.map((inst) => inst.id).join(", "),
-      );
-      console.error(
-        'Usage: yarn revoke-installations <inbox-id> "installation-id1,installation-id2"',
-      );
-      process.exit(1);
+
+      // Get user confirmation
+      process.stdout.write("\nDo you want to proceed? (y/N): ");
+
+      const confirmation = await new Promise<string>((resolve) => {
+        process.stdin.once("data", (data) => {
+          resolve(data.toString().trim().toLowerCase());
+        });
+      });
+
+      if (confirmation !== "y" && confirmation !== "yes") {
+        console.log("Operation cancelled.");
+        process.exit(0);
+      }
+
+      // Keep the first installation (arbitrary choice since user didn't specify)
+      installationsToKeepIds = [currentInstallations[0].id];
+      console.log(`✓ Keeping installation: ${installationsToKeepIds[0]}`);
     }
 
     // Find installations to revoke (all except the ones to keep)


### PR DESCRIPTION
### Add interactive confirmation prompt to revokeInstallations script when no installations are specified to keep
The `revokeInstallations.ts` script replaces error-based exit behavior with an interactive confirmation flow when no installations are specified to keep. The script displays a warning message, lists all available installation IDs with numbered indices, prompts for user confirmation with a yes/no question, and proceeds by keeping the first installation if confirmed. The implementation uses a Promise to wait for user input from stdin rather than immediately exiting with an error.

#### 📍Where to Start
Start with the modified logic in [revokeInstallations.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/207/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c) where the script handles the case when no installations are specified to keep.

----

_[Macroscope](https://app.macroscope.com) summarized 2a0a0ae._