### PR TITLE
update @xmtp/node-sdk to fix compatibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "typecheck": "tsc"
   },
   "resolutions": {
-    "@xmtp/node-sdk": "3.2.0"
+    "@xmtp/node-sdk": "3.2.1"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "3.2.0",
+    "@xmtp/node-sdk": "3.2.1",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,22 +2121,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@xmtp/node-bindings@npm:1.3.0"
-  checksum: 10/1ce331b662d4eb79d740d214bd3c6bf5aa361256bbb9be2ff49c66494156aa191528b8024e8c22f3b62c19b7ad0d4f7a3a57556fd49151aadf552a762b08f5b7
+"@xmtp/node-bindings@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@xmtp/node-bindings@npm:1.3.2"
+  checksum: 10/d07ae9152783b32f3a5b68c736f813c851d4941852a76e4bd743265a735ecb77b30504611d481c655a9e6d86635aebfe19676c21c636315209be59104d806030
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:3.2.0":
-  version: 3.2.0
-  resolution: "@xmtp/node-sdk@npm:3.2.0"
+"@xmtp/node-sdk@npm:3.2.1":
+  version: 3.2.1
+  resolution: "@xmtp/node-sdk@npm:3.2.1"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.3.0"
-  checksum: 10/31f6494c491ea103b87293181e353e00bdf2bc34616718521d667a39c818a8fcf200fbcf6427be06f3a9fecd231e6fe0d95f673f555075903b8e7b316c07d687
+    "@xmtp/node-bindings": "npm:1.3.2"
+  checksum: 10/aa5f8df2de685ded923129bd133d403e2eabbef00dfbbb542fdcb186ed6697a95efb672d8a3b1cf80b7d0af2ae9532b1857faf36f90f3d72061ba1d7aab18ba1
   languageName: node
   linkType: hard
 
@@ -5744,7 +5744,7 @@ __metadata:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^22.13.0"
-    "@xmtp/node-sdk": "npm:3.2.0"
+    "@xmtp/node-sdk": "npm:3.2.1"
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.3"


### PR DESCRIPTION
### Update @xmtp/node-sdk dependency from version 3.2.0 to 3.2.1 to fix compatibility issues
Updates the `@xmtp/node-sdk` dependency from version 3.2.0 to 3.2.1 in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/212/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and regenerates the corresponding lock file entries in [yarn.lock](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/212/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

#### 📍Where to Start
Start with the dependency changes in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/212/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to see the version update from 3.2.0 to 3.2.1.

----

_[Macroscope](https://app.macroscope.com) summarized 968b61b._