### PR TITLE
Refactor date handling for specific installation status

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -110,7 +110,15 @@ export const logAgentDetails = async (
 
     const conversations = await firstClient.conversations.list();
     const inboxState = await firstClient.preferences.inboxState();
+    const keyPackageStatuses =
+      await firstClient.getKeyPackageStatusesForInstallationIds([
+        installationId,
+      ]);
 
+    let createdDate = new Date();
+    let expiryDate = new Date();
+    createdDate = new Date(Number(keyPackageStatuses.createdAt) * 1000);
+    expiryDate = new Date(Number(keyPackageStatuses.validUntil) * 1000);
     console.log(`
     ✓ XMTP Client:
     • InboxId: ${inboxId}
@@ -119,6 +127,8 @@ export const logAgentDetails = async (
     • Conversations: ${conversations.length}
     • Installations: ${inboxState.installations.length}
     • InstallationId: ${installationId}
+    • Key Package created: ${createdDate.toLocaleString()}
+    • Key Package valid until: ${expiryDate.toLocaleString()}
     • Networks: ${environments}
     ${urls.map((url) => `• URL: ${url}`).join("\n")}`);
   }

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -117,8 +117,15 @@ export const logAgentDetails = async (
 
     let createdDate = new Date();
     let expiryDate = new Date();
-    createdDate = new Date(Number(keyPackageStatuses.createdAt) * 1000);
-    expiryDate = new Date(Number(keyPackageStatuses.validUntil) * 1000);
+
+    // Extract key package status for the specific installation
+    const keyPackageStatus = keyPackageStatuses[installationId];
+    if (keyPackageStatus.lifetime) {
+      createdDate = new Date(
+        Number(keyPackageStatus.lifetime.notBefore) * 1000,
+      );
+      expiryDate = new Date(Number(keyPackageStatus.lifetime.notAfter) * 1000);
+    }
     console.log(`
     ✓ XMTP Client:
     • InboxId: ${inboxId}


### PR DESCRIPTION
### Update `logAgentDetails` function in helpers/client.ts to extract installation-specific key package status and access timestamp data from lifetime property using notBefore and notAfter properties
The `logAgentDetails` function in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/214/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) now extracts key package status for a specific installation ID from the `keyPackageStatuses` object and accesses timestamp information from a nested `lifetime` property. The function uses `notBefore` and `notAfter` properties instead of the previous `createdAt` and `validUntil` properties, and includes a check for the existence of the `lifetime` property before accessing timestamps.

#### 📍Where to Start
Start with the `logAgentDetails` function in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/214/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1).

----

_[Macroscope](https://app.macroscope.com) summarized 56b39ce._