### PR TITLE
Add usage section to README for clarity

### DIFF
--- a/examples/xmtp-secret-word-group/README.md
+++ b/examples/xmtp-secret-word-group/README.md
@@ -41,6 +41,8 @@ yarn gen:keys
 > [!WARNING]
 > The `gen:keys` command appends keys to your existing `.env` file.
 
+## Usage
+
 1. Update the secret word in `index.ts`:
 
 ```tsx


### PR DESCRIPTION
### Add usage section header to README for clarity in examples/xmtp-secret-word-group directory
Adds a `## Usage` section header to the [examples/xmtp-secret-word-group/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/226/files#diff-2e548a907e9fa31bb2931c6699827509d49cb46f45e18dd641661198c8fce298) file between the warning about the `gen:keys` command and the numbered instructions that follow.

#### 📍Where to Start
Start with the [examples/xmtp-secret-word-group/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/226/files#diff-2e548a907e9fa31bb2931c6699827509d49cb46f45e18dd641661198c8fce298) file to review the added section header.

----

_[Macroscope](https://app.macroscope.com) summarized c36db43._