### PR TITLE
Add example for thinking reaction agent functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository provides examples of agents that use the [XMTP](https://docs.xmt
 - [xmtp-group-welcome](/examples/xmtp-group-welcome/): Sends a welcome message when its added and to new members
 - [xmtp-smart-wallet](/examples/xmtp-smart-wallet/): Agent that uses a smart wallet to send messages
 - [xmtp-attachments](/examples/xmtp-attachments/): Agent that sends and receives images
+- [xmtp-thinking-reaction](/examples/xmtp-thinking-reaction/): Agent that reacts to messages with a thinking emoji
 - [xmtp-queue-dual-client](/examples/xmtp-queue-dual-client/): Agent that uses two clients to send and receive messages
 - [xmtp-multiple-workers](/examples/xmtp-multiple-workers/): Agent that uses multiple workers to send and receive messages
 - [xmtp-stream-callbacks](/examples/xmtp-stream-callbacks/): Stream callbacks for XMTP agents

--- a/examples/xmtp-thinking-reaction/README.md
+++ b/examples/xmtp-thinking-reaction/README.md
@@ -1,4 +1,4 @@
-# Thinking Reaction Agent
+# Thinking reaction example
 
 This agent reacts to messages with a thinking emoji (⏳), waits 2 seconds, then sends a response (and removes the reaction).
 

--- a/examples/xmtp-thinking-reaction/README.md
+++ b/examples/xmtp-thinking-reaction/README.md
@@ -1,0 +1,49 @@
+# Thinking Reaction Agent
+
+This agent reacts to messages with a thinking emoji (⏳), waits 2 seconds, then sends a response (and removes the reaction).
+
+## Getting started
+
+> [!TIP]
+> See XMTP's [cursor rules](/.cursor/README.md) for vibe coding agents and best practices.
+
+### Requirements
+
+- Node.js v20 or higher
+- Yarn v4 or higher
+- Docker (optional, for local network)
+
+### Environment variables
+
+To run your XMTP agent, you must create a `.env` file with the following variables:
+
+```bash
+WALLET_KEY= # the private key of the wallet
+ENCRYPTION_KEY= # encryption key for the local database
+XMTP_ENV=dev # local, dev, production
+```
+
+You can generate random xmtp keys with the following command:
+
+```bash
+yarn gen:keys
+```
+
+> [!WARNING]
+> Running the `gen:keys` command will append keys to your existing `.env` file.
+
+### Run the agent
+
+```bash
+# git clone repo
+git clone https://github.com/ephemeraHQ/xmtp-agent-examples.git
+# go to the folder
+cd xmtp-agent-examples
+cd examples/xmtp-stream-callbacks
+# install packages
+yarn
+# generate random xmtp keys (optional)
+yarn gen:keys
+# run the example
+yarn dev
+```

--- a/examples/xmtp-thinking-reaction/index.ts
+++ b/examples/xmtp-thinking-reaction/index.ts
@@ -71,7 +71,7 @@ async function main() {
           content: "⏳",
           reference: message.id,
           schema: "shortcode",
-        },
+        } as Reaction,
         ContentTypeReaction,
       );
 
@@ -90,7 +90,7 @@ async function main() {
           content: "⏳",
           reference: message.id,
           schema: "shortcode",
-        },
+        } as Reaction,
         ContentTypeReaction,
       );
       console.log("✅ Response sent successfully");

--- a/examples/xmtp-thinking-reaction/index.ts
+++ b/examples/xmtp-thinking-reaction/index.ts
@@ -1,0 +1,107 @@
+import {
+  createSigner,
+  getEncryptionKeyFromHex,
+  logAgentDetails,
+  validateEnvironment,
+} from "@helpers/client";
+import {
+  ContentTypeReaction,
+  ReactionCodec,
+  type Reaction,
+} from "@xmtp/content-type-reaction";
+import { Client, type XmtpEnv } from "@xmtp/node-sdk";
+
+/* Get the wallet key associated to the public key of
+ * the agent and the encryption key for the local db
+ * that stores your agent's messages */
+const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
+  "WALLET_KEY",
+  "ENCRYPTION_KEY",
+  "XMTP_ENV",
+]);
+
+/* Create the signer using viem and parse the encryption key for the local db */
+const signer = createSigner(WALLET_KEY);
+const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+
+// Helper function to sleep for a specified number of milliseconds
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
+    env: XMTP_ENV as XmtpEnv,
+    codecs: [new ReactionCodec()],
+  });
+  void logAgentDetails(client as Client);
+
+  console.log("✓ Syncing conversations...");
+  await client.conversations.sync();
+
+  console.log("Waiting for messages...");
+  const stream = await client.conversations.streamAllMessages();
+  for await (const message of stream) {
+    // Skip if the message is from the agent
+    if (message.senderInboxId.toLowerCase() === client.inboxId.toLowerCase()) {
+      continue;
+    }
+    // Skip if the message is not a text message
+    if (message.contentType?.typeId !== "text") {
+      continue;
+    }
+
+    const conversation = await client.conversations.getConversationById(
+      message.conversationId,
+    );
+
+    if (!conversation) {
+      console.log("Unable to find conversation, skipping");
+      continue;
+    }
+
+    try {
+      const messageContent = message.content as string;
+      console.log(`Received message: ${messageContent}`);
+
+      // Step 1: React with thinking emoji
+      console.log("🤔 Reacting with thinking emoji...");
+      await conversation.send(
+        {
+          action: "added",
+          content: "⏳",
+          reference: message.id,
+          schema: "shortcode",
+        },
+        ContentTypeReaction,
+      );
+
+      // Step 2: Sleep for 2 seconds
+      console.log("💤 Sleeping for 2 seconds...");
+      await sleep(2000);
+
+      // Step 3: Send response
+      console.log("💭 Sending response...");
+      await conversation.send(
+        "I've been thinking about your message and here's my response!",
+      );
+      await conversation.send(
+        {
+          action: "removed",
+          content: "⏳",
+          reference: message.id,
+          schema: "shortcode",
+        },
+        ContentTypeReaction,
+      );
+      console.log("✅ Response sent successfully");
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.error("Error processing message:", errorMessage);
+    }
+  }
+
+  console.log("Message stream started");
+}
+
+main().catch(console.error);

--- a/examples/xmtp-thinking-reaction/package.json
+++ b/examples/xmtp-thinking-reaction/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@examples/xmtp-thinking-reaction",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx --watch index.ts",
+    "gen:keys": "tsx ../../scripts/generateKeys.ts",
+    "lint": "cd ../.. && yarn eslint examples/xmtp-thinking-reaction",
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@xmtp/content-type-reaction": "^2.0.2",
+    "@xmtp/node-sdk": "*"
+  },
+  "devDependencies": {
+    "tsx": "*",
+    "typescript": "*"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,6 +1032,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@examples/xmtp-thinking-reaction@workspace:examples/xmtp-thinking-reaction":
+  version: 0.0.0-use.local
+  resolution: "@examples/xmtp-thinking-reaction@workspace:examples/xmtp-thinking-reaction"
+  dependencies:
+    "@xmtp/content-type-reaction": "npm:^2.0.2"
+    "@xmtp/node-sdk": "npm:*"
+    tsx: "npm:*"
+    typescript: "npm:*"
+  languageName: unknown
+  linkType: soft
+
 "@examples/xmtp-transactions@workspace:examples/xmtp-transactions":
   version: 0.0.0-use.local
   resolution: "@examples/xmtp-transactions@workspace:examples/xmtp-transactions"
@@ -2091,6 +2102,15 @@ __metadata:
   dependencies:
     "@xmtp/proto": "npm:^3.78.0"
   checksum: 10/9c115c1e792bca5e5e7180ba5494786bd3554265bc0ccdcb26d645689634ae239cefb3996bbbe493a487a2c8c7bf4e85954f4063811f784021afe16e58b1b03b
+  languageName: node
+  linkType: hard
+
+"@xmtp/content-type-reaction@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@xmtp/content-type-reaction@npm:2.0.2"
+  dependencies:
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+  checksum: 10/704e64c79ae44fa002265d74b0f19a423ad2f7164397caafe842cd868d122d89b2b083989394bad50186b1aaf9944f632aa35cbbd2af840e9498d64cd52ad4f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Add example for thinking reaction agent functionality that reacts to messages with a thinking emoji
Adds a new XMTP example agent called `xmtp-thinking-reaction` that demonstrates message reaction functionality. The agent reacts to incoming text messages with a thinking emoji (⏳), waits 2 seconds, sends a response, and removes the reaction. The implementation includes:

- New agent implementation in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/231/files#diff-fbe4262c33a80d0fe627ab1623ec5b6c6b952ec5c3894eefff19e71324742a04) that uses the `@xmtp/content-type-reaction` codec
- Package configuration in [package.json](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/231/files#diff-6ded8b77881ed328da3dc73a10be4e1cf29486ed3db1a4c938457537c379f37b) with dependencies on XMTP libraries
- Documentation in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/231/files#diff-773ac994bba2157424a1fa8f6f9cbd59218b3f6a7b6d9c618747b139b81f69e6) explaining setup and functionality
- Updated main [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/231/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to include the new example in the agent list

#### 📍Where to Start
Start with the main agent implementation in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/231/files#diff-fbe4262c33a80d0fe627ab1623ec5b6c6b952ec5c3894eefff19e71324742a04) to understand the message handling and reaction logic.

----

_[Macroscope](https://app.macroscope.com) summarized e902851._