### PR TITLE
Add logging level configuration for better debugging

### DIFF
--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -4,7 +4,7 @@ import {
   logAgentDetails,
   validateEnvironment,
 } from "@helpers/client";
-import { Client, type XmtpEnv } from "@xmtp/node-sdk";
+import { Client, type LogLevel, type XmtpEnv } from "@xmtp/node-sdk";
 import OpenAI from "openai";
 
 /* Get the wallet key associated to the public key of
@@ -42,6 +42,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -4,7 +4,7 @@ import {
   logAgentDetails,
   validateEnvironment,
 } from "@helpers/client";
-import { Client, type XmtpEnv } from "@xmtp/node-sdk";
+import { Client, type LogLevel, type XmtpEnv } from "@xmtp/node-sdk";
 
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
@@ -22,6 +22,7 @@ const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });
   void logAgentDetails(client);


### PR DESCRIPTION
### Configure XMTP Client logging level to "warn" for better debugging in example applications
The changes add logging level configuration to XMTP Client initialization in two example applications. Both [examples/xmtp-gaia/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/235/files#diff-401a0b38ce6b408aaf287e061516884ac4e407ae1d1591d707bfc3e2db832321) and [examples/xmtp-gm/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/235/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9) now import the `LogLevel` type and set the `loggingLevel` option to "warn" when creating Client instances.

#### 📍Where to Start
Start with the main function in [examples/xmtp-gaia/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/235/files#diff-401a0b38ce6b408aaf287e061516884ac4e407ae1d1591d707bfc3e2db832321) where the `Client.create` method now includes the `loggingLevel` configuration.

----

_[Macroscope](https://app.macroscope.com) summarized 1949391._