### PR TITLE
Add appVersion to client creation for consistency

### DIFF
--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -240,7 +240,7 @@ async function main() {
   const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 
@@ -936,7 +936,7 @@ if (!fs.existsSync(dbPath)) {
 // Create a client with db path
 const client = await Client.create(signer, {
   dbEncryptionKey,
-appVersion:"example/1.0.0",
+appVersion:"example-agent/1.0.0",
   env: XMTP_ENV as XmtpEnv,
   // Use a unique DB directory
   dbPath,

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -240,6 +240,7 @@ async function main() {
   const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 
@@ -935,6 +936,7 @@ if (!fs.existsSync(dbPath)) {
 // Create a client with db path
 const client = await Client.create(signer, {
   dbEncryptionKey,
+appVersion:"agent-examples/1.0.0",
   env: XMTP_ENV as XmtpEnv,
   // Use a unique DB directory
   dbPath,

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -240,7 +240,7 @@ async function main() {
   const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 
@@ -936,7 +936,7 @@ if (!fs.existsSync(dbPath)) {
 // Create a client with db path
 const client = await Client.create(signer, {
   dbEncryptionKey,
-appVersion:"agent-examples/1.0.0",
+appVersion:"example/1.0.0",
   env: XMTP_ENV as XmtpEnv,
   // Use a unique DB directory
   dbPath,

--- a/examples/xmtp-attachments/index.ts
+++ b/examples/xmtp-attachments/index.ts
@@ -107,7 +107,7 @@ async function createRemoteAttachmentFromData(
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new RemoteAttachmentCodec(), new AttachmentCodec()],
   });

--- a/examples/xmtp-attachments/index.ts
+++ b/examples/xmtp-attachments/index.ts
@@ -107,7 +107,7 @@ async function createRemoteAttachmentFromData(
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new RemoteAttachmentCodec(), new AttachmentCodec()],
   });

--- a/examples/xmtp-attachments/index.ts
+++ b/examples/xmtp-attachments/index.ts
@@ -107,6 +107,7 @@ async function createRemoteAttachmentFromData(
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new RemoteAttachmentCodec(), new AttachmentCodec()],
   });

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -120,7 +120,7 @@ async function initializeXmtpClient() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     dbPath: XMTP_STORAGE_DIR + `/${XMTP_ENV}-${address}`,
   });

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -120,7 +120,7 @@ async function initializeXmtpClient() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     dbPath: XMTP_STORAGE_DIR + `/${XMTP_ENV}-${address}`,
   });

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -120,6 +120,7 @@ async function initializeXmtpClient() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     dbPath: XMTP_STORAGE_DIR + `/${XMTP_ENV}-${address}`,
   });

--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -42,6 +42,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -42,7 +42,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -42,7 +42,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-gated-group/index.ts
+++ b/examples/xmtp-gated-group/index.ts
@@ -49,7 +49,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-gated-group/index.ts
+++ b/examples/xmtp-gated-group/index.ts
@@ -49,6 +49,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-gated-group/index.ts
+++ b/examples/xmtp-gated-group/index.ts
@@ -49,7 +49,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -22,7 +22,7 @@ const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -22,6 +22,7 @@ const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -22,7 +22,7 @@ const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     loggingLevel: "warn" as LogLevel,
     env: XMTP_ENV as XmtpEnv,
   });

--- a/examples/xmtp-gpt/index.ts
+++ b/examples/xmtp-gpt/index.ts
@@ -31,7 +31,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-gpt/index.ts
+++ b/examples/xmtp-gpt/index.ts
@@ -31,6 +31,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-gpt/index.ts
+++ b/examples/xmtp-gpt/index.ts
@@ -31,7 +31,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-inline-actions/index.ts
+++ b/examples/xmtp-inline-actions/index.ts
@@ -42,7 +42,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [
       new WalletSendCallsCodec(),

--- a/examples/xmtp-inline-actions/index.ts
+++ b/examples/xmtp-inline-actions/index.ts
@@ -42,6 +42,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [
       new WalletSendCallsCodec(),

--- a/examples/xmtp-inline-actions/index.ts
+++ b/examples/xmtp-inline-actions/index.ts
@@ -42,7 +42,7 @@ async function main() {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [
       new WalletSendCallsCodec(),

--- a/examples/xmtp-multiple-workers/workers.ts
+++ b/examples/xmtp-multiple-workers/workers.ts
@@ -58,7 +58,7 @@ export class XmtpWorkerManager {
     // Create XMTP client
     const client = await Client.create(signer, {
       dbEncryptionKey,
-      appVersion: "example/1.0.0",
+      appVersion: "example-agent/1.0.0",
       env: config.xmtpEnv,
     });
 

--- a/examples/xmtp-multiple-workers/workers.ts
+++ b/examples/xmtp-multiple-workers/workers.ts
@@ -58,7 +58,7 @@ export class XmtpWorkerManager {
     // Create XMTP client
     const client = await Client.create(signer, {
       dbEncryptionKey,
-      appVersion: "agent-examples/1.0.0",
+      appVersion: "example/1.0.0",
       env: config.xmtpEnv,
     });
 

--- a/examples/xmtp-multiple-workers/workers.ts
+++ b/examples/xmtp-multiple-workers/workers.ts
@@ -58,6 +58,7 @@ export class XmtpWorkerManager {
     // Create XMTP client
     const client = await Client.create(signer, {
       dbEncryptionKey,
+      appVersion: "agent-examples/1.0.0",
       env: config.xmtpEnv,
     });
 

--- a/examples/xmtp-queue-dual-client/index.ts
+++ b/examples/xmtp-queue-dual-client/index.ts
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
   // Create receiving client
   const receivingClient = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
     dbPath: getDbPath(XMTP_ENV + "-receiving"),
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
   // Create sending client
   const sendingClient = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
     dbPath: getDbPath(XMTP_ENV + "-sending"),

--- a/examples/xmtp-queue-dual-client/index.ts
+++ b/examples/xmtp-queue-dual-client/index.ts
@@ -41,6 +41,7 @@ async function main(): Promise<void> {
   // Create receiving client
   const receivingClient = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
     dbPath: getDbPath(XMTP_ENV + "-receiving"),
@@ -52,6 +53,7 @@ async function main(): Promise<void> {
   // Create sending client
   const sendingClient = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
     dbPath: getDbPath(XMTP_ENV + "-sending"),

--- a/examples/xmtp-queue-dual-client/index.ts
+++ b/examples/xmtp-queue-dual-client/index.ts
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
   // Create receiving client
   const receivingClient = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
     dbPath: getDbPath(XMTP_ENV + "-receiving"),
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
   // Create sending client
   const sendingClient = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     loggingLevel: LOGGING_LEVEL as LogLevel,
     dbPath: getDbPath(XMTP_ENV + "-sending"),

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -35,6 +35,7 @@ const main = async () => {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -35,7 +35,7 @@ const main = async () => {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -35,7 +35,7 @@ const main = async () => {
 
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
   });
 

--- a/examples/xmtp-thinking-reaction/index.ts
+++ b/examples/xmtp-thinking-reaction/index.ts
@@ -30,7 +30,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new ReactionCodec()],
   });

--- a/examples/xmtp-thinking-reaction/index.ts
+++ b/examples/xmtp-thinking-reaction/index.ts
@@ -30,7 +30,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new ReactionCodec()],
   });

--- a/examples/xmtp-thinking-reaction/index.ts
+++ b/examples/xmtp-thinking-reaction/index.ts
@@ -30,6 +30,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new ReactionCodec()],
   });

--- a/examples/xmtp-transactions/index.ts
+++ b/examples/xmtp-transactions/index.ts
@@ -31,6 +31,7 @@ async function main() {
   /* Initialize the xmtp client */
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new WalletSendCallsCodec(), new TransactionReferenceCodec()],
   });

--- a/examples/xmtp-transactions/index.ts
+++ b/examples/xmtp-transactions/index.ts
@@ -31,7 +31,7 @@ async function main() {
   /* Initialize the xmtp client */
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new WalletSendCallsCodec(), new TransactionReferenceCodec()],
   });

--- a/examples/xmtp-transactions/index.ts
+++ b/examples/xmtp-transactions/index.ts
@@ -31,7 +31,7 @@ async function main() {
   /* Initialize the xmtp client */
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new WalletSendCallsCodec(), new TransactionReferenceCodec()],
   });

--- a/examples/xmtp-welcome-message/README.md
+++ b/examples/xmtp-welcome-message/README.md
@@ -86,6 +86,7 @@ const welcomeActions: ActionsContent = {
 // Register codecs
 const client = await Client.create(signer, {
   dbEncryptionKey,
+  appVersion: "agent-examples/1.0.0",
   env: XMTP_ENV as XmtpEnv,
   codecs: [new ActionsCodec(), new IntentCodec()],
 });

--- a/examples/xmtp-welcome-message/README.md
+++ b/examples/xmtp-welcome-message/README.md
@@ -86,7 +86,7 @@ const welcomeActions: ActionsContent = {
 // Register codecs
 const client = await Client.create(signer, {
   dbEncryptionKey,
-  appVersion: "agent-examples/1.0.0",
+  appVersion: "example/1.0.0",
   env: XMTP_ENV as XmtpEnv,
   codecs: [new ActionsCodec(), new IntentCodec()],
 });

--- a/examples/xmtp-welcome-message/README.md
+++ b/examples/xmtp-welcome-message/README.md
@@ -86,7 +86,7 @@ const welcomeActions: ActionsContent = {
 // Register codecs
 const client = await Client.create(signer, {
   dbEncryptionKey,
-  appVersion: "example/1.0.0",
+  appVersion: "example-agent/1.0.0",
   env: XMTP_ENV as XmtpEnv,
   codecs: [new ActionsCodec(), new IntentCodec()],
 });

--- a/examples/xmtp-welcome-message/index.ts
+++ b/examples/xmtp-welcome-message/index.ts
@@ -220,6 +220,7 @@ async function handleMessage(message: DecodedMessage, client: Client) {
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
+    appVersion: "agent-examples/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new ActionsCodec(), new IntentCodec()],
   });

--- a/examples/xmtp-welcome-message/index.ts
+++ b/examples/xmtp-welcome-message/index.ts
@@ -220,7 +220,7 @@ async function handleMessage(message: DecodedMessage, client: Client) {
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "example/1.0.0",
+    appVersion: "example-agent/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new ActionsCodec(), new IntentCodec()],
   });

--- a/examples/xmtp-welcome-message/index.ts
+++ b/examples/xmtp-welcome-message/index.ts
@@ -220,7 +220,7 @@ async function handleMessage(message: DecodedMessage, client: Client) {
 async function main() {
   const client = await Client.create(signer, {
     dbEncryptionKey,
-    appVersion: "agent-examples/1.0.0",
+    appVersion: "example/1.0.0",
     env: XMTP_ENV as XmtpEnv,
     codecs: [new ActionsCodec(), new IntentCodec()],
   });


### PR DESCRIPTION
### Add `appVersion: "example-agent/1.0.0"` to `Client.create` calls across XMTP examples and `.cursor/rules/xmtp.mdc` for consistency
- Update XMTP example `Client.create` option objects to include `appVersion: "example-agent/1.0.0"`, e.g., [examples/xmtp-attachments/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-4df3f9ac109dc8c2be640a3421cb2605ab2abf95e4ed3e30048d112b8c0aaaea), [examples/xmtp-gpt/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-15d6aa15c3ab27df52cef86d38f2bd99d547836e4b05ed510119c9aa34d90ef6), [examples/xmtp-queue-dual-client/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-12206c096c41164388d4ee5667242d27e93e10d89e76540088a30724f4138ced), and [examples/xmtp-multiple-workers/workers.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-fc7a04ffb2ee146143cf201c0ec6b92f9fb33f2b92185605c3d1389f09f22e60).
- Update configuration and documentation snippets to include the same option in [.cursor/rules/xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20) and [examples/xmtp-welcome-message/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-bcefcc65b3d8575ee9f2c0e0e44045c6be7bfb8bf96abd4296d1e1a46002f931).

#### 📍Where to Start
Start with the `Client.create` examples in [.cursor/rules/xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20), then review a representative implementation such as [examples/xmtp-attachments/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/248/files#diff-4df3f9ac109dc8c2be640a3421cb2605ab2abf95e4ed3e30048d112b8c0aaaea) to confirm the option is applied consistently.

----

_[Macroscope](https://app.macroscope.com) summarized 53a9d2c._