### PR TITLE
Rename encryption key for clarity and consistency

### DIFF
--- a/.cursor/rules/monorepo-guidelines.mdc
+++ b/.cursor/rules/monorepo-guidelines.mdc
@@ -1,8 +1,9 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: true
 ---
+
 # Working with XMTP agents in this monorepo
 
 This is the monorepo for XMTP agents. It contains many examples of agents on XMTP.
@@ -56,7 +57,7 @@ XMTP_ENV=dev
 
 # Private keys (generate with yarn gen:keys)
 WALLET_KEY=your_private_key_here
-ENCRYPTION_KEY=your_encryption_key_here
+DB_ENCRYPTION_KEY=your_encryption_key_here
 ```
 
 ## Running an agent

--- a/.cursor/rules/readme.mdc
+++ b/.cursor/rules/readme.mdc
@@ -27,7 +27,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/.cursor/rules/xmtp.mdc
+++ b/.cursor/rules/xmtp.mdc
@@ -29,7 +29,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
     ```typescript
     const signer = createSigner(WALLET_KEY);
-    const encryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+    const encryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
     const client = await Client.create(signer, {
       dbEncryptionKey: encryptionKey,
       env: XMTP_ENV as XmtpEnv,
@@ -183,7 +183,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
 
     ```bash
     WALLET_KEY= # the private key of the wallet
-    ENCRYPTION_KEY= # encryption key for the local database
+    DB_ENCRYPTION_KEY= # encryption key for the local database
     XMTP_ENV=dev # local, dev, production
     ```
 
@@ -207,7 +207,7 @@ You're an expert in writing TypeScript with Node.js. Generate **high-quality XMT
     ```bash
     # Generic keys
     WALLET_KEY=0x...
-    ENCRYPTION_KEY=...
+    DB_ENCRYPTION_KEY=...
     XMTP_ENV=dev
     # public key is 0x...
     ```
@@ -237,7 +237,7 @@ const MEMBER_ADDRESS = "0x7c40611372d354799d138542e77243c284e460b2";
 async function main() {
   // Initialize client
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
   const client = await Client.create(signer, {
     dbEncryptionKey,
     appVersion: "example-agent/1.0.0",

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
 XMTP_ENV=dev # local, dev, production

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To run an example XMTP agent, you must create a `.env` file with the following v
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/examples/xmtp-attachments/.env.example
+++ b/examples/xmtp-attachments/.env.example
@@ -1,5 +1,5 @@
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
 XMTP_ENV=dev # local, dev, production
 
 # Pinata API Key

--- a/examples/xmtp-attachments/README.md
+++ b/examples/xmtp-attachments/README.md
@@ -31,7 +31,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/examples/xmtp-attachments/index.ts
+++ b/examples/xmtp-attachments/index.ts
@@ -16,14 +16,14 @@ import {
 import { Client, type XmtpEnv } from "@xmtp/node-sdk";
 import { uploadToPinata } from "./upload";
 
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
   "WALLET_KEY",
-  "ENCRYPTION_KEY",
+  "DB_ENCRYPTION_KEY",
   "XMTP_ENV",
 ]);
 
 const signer = createSigner(WALLET_KEY);
-const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
 // Check this path is correct in your case of errors
 const DEFAULT_IMAGE_PATH = "./logo.png";

--- a/examples/xmtp-coinbase-agentkit/.env.example
+++ b/examples/xmtp-coinbase-agentkit/.env.example
@@ -1,5 +1,5 @@
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 
 
 NETWORK_ID=base-sepolia # base-mainnet or others

--- a/examples/xmtp-coinbase-agentkit/README.md
+++ b/examples/xmtp-coinbase-agentkit/README.md
@@ -24,7 +24,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is
 
 NETWORK_ID=base-sepolia # base-mainnet or others

--- a/examples/xmtp-coinbase-agentkit/index.ts
+++ b/examples/xmtp-coinbase-agentkit/index.ts
@@ -27,7 +27,7 @@ import {
 
 const {
   WALLET_KEY,
-  ENCRYPTION_KEY,
+  DB_ENCRYPTION_KEY,
   XMTP_ENV,
   CDP_API_KEY_NAME,
   CDP_API_KEY_PRIVATE_KEY,
@@ -35,7 +35,7 @@ const {
   OPENAI_API_KEY,
 } = validateEnvironment([
   "WALLET_KEY",
-  "ENCRYPTION_KEY",
+  "DB_ENCRYPTION_KEY",
   "XMTP_ENV",
   "CDP_API_KEY_NAME",
   "CDP_API_KEY_PRIVATE_KEY",
@@ -113,7 +113,7 @@ function getWalletData(userId: string): string | null {
  */
 async function initializeXmtpClient() {
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
   const identifier = await signer.getIdentifier();
   const address = identifier.identifier;

--- a/examples/xmtp-gaia/.env.example
+++ b/examples/xmtp-gaia/.env.example
@@ -1,6 +1,6 @@
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 0x..
 
 # GAIA example

--- a/examples/xmtp-gaia/README.md
+++ b/examples/xmtp-gaia/README.md
@@ -21,7 +21,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
 XMTP_ENV=dev # local, dev, production
 GAIA_API_KEY= # Your API key from https://gaianet.ai
 GAIA_NODE_URL= # Your custom Gaia node URL or a public node, ex: https://llama8b.gaia.domains/v1

--- a/examples/xmtp-gaia/index.ts
+++ b/examples/xmtp-gaia/index.ts
@@ -12,14 +12,14 @@ import OpenAI from "openai";
  * that stores your agent's messages */
 const {
   WALLET_KEY,
-  ENCRYPTION_KEY,
+  DB_ENCRYPTION_KEY,
   XMTP_ENV,
   GAIA_NODE_URL,
   GAIA_API_KEY,
   GAIA_MODEL_NAME,
 } = validateEnvironment([
   "WALLET_KEY",
-  "ENCRYPTION_KEY",
+  "DB_ENCRYPTION_KEY",
   "XMTP_ENV",
   "GAIA_NODE_URL",
   "GAIA_API_KEY",
@@ -38,7 +38,7 @@ const openai = new OpenAI({
 async function main() {
   /* Create the signer using viem and parse the encryption key for the local db */
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
   const client = await Client.create(signer, {
     dbEncryptionKey,

--- a/examples/xmtp-gated-group/README.md
+++ b/examples/xmtp-gated-group/README.md
@@ -28,7 +28,7 @@ To run your XMTP agent, create a `.env` file with the following variables:
 ```bash
 SECRET_WORD= # the secret word to join the group
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/examples/xmtp-gated-group/index.ts
+++ b/examples/xmtp-gated-group/index.ts
@@ -7,10 +7,10 @@ import {
 import { Client, type Group, type XmtpEnv } from "@xmtp/node-sdk";
 
 // Validate required environment variables
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV, SECRET_WORD } =
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV, SECRET_WORD } =
   validateEnvironment([
     "WALLET_KEY",
-    "ENCRYPTION_KEY",
+    "DB_ENCRYPTION_KEY",
     "XMTP_ENV",
     "SECRET_WORD",
   ]);
@@ -45,7 +45,7 @@ const usersInGroup = new Set<string>();
 async function main() {
   // Initialize XMTP client
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
   const client = await Client.create(signer, {
     dbEncryptionKey,

--- a/examples/xmtp-gm/.env.example
+++ b/examples/xmtp-gm/.env.example
@@ -1,4 +1,4 @@
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
 XMTP_ENV=dev # local, dev, production
 

--- a/examples/xmtp-gm/README.md
+++ b/examples/xmtp-gm/README.md
@@ -21,7 +21,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/examples/xmtp-gm/index.ts
+++ b/examples/xmtp-gm/index.ts
@@ -9,15 +9,15 @@ import { Client, type LogLevel, type XmtpEnv } from "@xmtp/node-sdk";
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
  * that stores your agent's messages */
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
   "WALLET_KEY",
-  "ENCRYPTION_KEY",
+  "DB_ENCRYPTION_KEY",
   "XMTP_ENV",
 ]);
 
 /* Create the signer using viem and parse the encryption key for the local db */
 const signer = createSigner(WALLET_KEY);
-const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
 async function main() {
   const client = await Client.create(signer, {

--- a/examples/xmtp-gpt/.env.example
+++ b/examples/xmtp-gpt/.env.example
@@ -1,6 +1,6 @@
 XMTP_ENV=dev # local, dev, production
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 0x..
 
 OPENAI_API_KEY= # the API key for the OpenAI node

--- a/examples/xmtp-gpt/README.md
+++ b/examples/xmtp-gpt/README.md
@@ -20,7 +20,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 OPENAI_API_KEY= # the API key for the OpenAI API
 ```

--- a/examples/xmtp-gpt/index.ts
+++ b/examples/xmtp-gpt/index.ts
@@ -10,10 +10,10 @@ import OpenAI from "openai";
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
  * that stores your agent's messages */
-const { WALLET_KEY, ENCRYPTION_KEY, OPENAI_API_KEY, XMTP_ENV } =
+const { WALLET_KEY, DB_ENCRYPTION_KEY, OPENAI_API_KEY, XMTP_ENV } =
   validateEnvironment([
     "WALLET_KEY",
-    "ENCRYPTION_KEY",
+    "DB_ENCRYPTION_KEY",
     "OPENAI_API_KEY",
     "XMTP_ENV",
   ]);
@@ -27,7 +27,7 @@ const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 async function main() {
   /* Create the signer using viem and parse the encryption key for the local db */
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
   const client = await Client.create(signer, {
     dbEncryptionKey,

--- a/examples/xmtp-inline-actions/.env.example
+++ b/examples/xmtp-inline-actions/.env.example
@@ -1,4 +1,4 @@
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
 XMTP_ENV=dev # local, dev, production
 

--- a/examples/xmtp-inline-actions/README.md
+++ b/examples/xmtp-inline-actions/README.md
@@ -75,7 +75,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 NETWORK_ID=base-sepolia # base-mainnet or others
 ```

--- a/examples/xmtp-inline-actions/index.ts
+++ b/examples/xmtp-inline-actions/index.ts
@@ -20,10 +20,10 @@ import { ActionsCodec } from "./types/ActionsContent";
 import { IntentCodec, type IntentContent } from "./types/IntentContent";
 
 // Validate required environment variables
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV, NETWORK_ID } =
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV, NETWORK_ID } =
   validateEnvironment([
     "WALLET_KEY",
-    "ENCRYPTION_KEY",
+    "DB_ENCRYPTION_KEY",
     "XMTP_ENV",
     "NETWORK_ID",
   ]);
@@ -38,7 +38,7 @@ async function main() {
 
   // Create XMTP client
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
   const client = await Client.create(signer, {
     dbEncryptionKey,

--- a/examples/xmtp-multiple-workers/.env.example
+++ b/examples/xmtp-multiple-workers/.env.example
@@ -1,10 +1,10 @@
 XMTP_ENV=dev # local, dev, production
 
 WALLET_KEY_AGENT1= # the private key of the wallet
-ENCRYPTION_KEY_AGENT1= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY_AGENT1= # a second random 32 bytes encryption key for local db encryption
 
 WALLET_KEY_AGENT2= # the private key of the wallet
-ENCRYPTION_KEY_AGENT2= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY_AGENT2= # a second random 32 bytes encryption key for local db encryption
 
 WALLET_KEY_AGENT3= # the private key of the wallet
-ENCRYPTION_KEY_AGENT3= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY_AGENT3= # a second random 32 bytes encryption key for local db encryption

--- a/examples/xmtp-multiple-workers/README.md
+++ b/examples/xmtp-multiple-workers/README.md
@@ -22,15 +22,15 @@ XMTP_ENV=dev # local, dev, production
 
 # keys for agent 1
 WALLET_KEY_AGENT1= # the private key of the wallet
-ENCRYPTION_KEY_AGENT1= # encryption key for local db encryption
+DB_ENCRYPTION_KEY_AGENT1= # encryption key for local db encryption
 
 # keys for agent 2
 WALLET_KEY_AGENT2= # the private key of the wallet
-ENCRYPTION_KEY_AGENT2= # encryption key for local db encryption
+DB_ENCRYPTION_KEY_AGENT2= # encryption key for local db encryption
 
 # keys for agent 3
 WALLET_KEY_AGENT3= # the private key of the wallet
-ENCRYPTION_KEY_AGENT3= # encryption key for local db encryption
+DB_ENCRYPTION_KEY_AGENT3= # encryption key for local db encryption
 ```
 
 You can generate random xmtp keys with the following command:
@@ -68,19 +68,19 @@ const workerConfigs: WorkerConfig[] = [
   {
     name: "agent1",
     walletKey: WALLET_KEY_AGENT1,
-    encryptionKey: ENCRYPTION_KEY_AGENT1,
+    encryptionKey: DB_ENCRYPTION_KEY_AGENT1,
     xmtpEnv: XMTP_ENV as XmtpEnv,
   },
   {
     name: "agent2",
     walletKey: WALLET_KEY_AGENT2,
-    encryptionKey: ENCRYPTION_KEY_AGENT2,
+    encryptionKey: DB_ENCRYPTION_KEY_AGENT2,
     xmtpEnv: XMTP_ENV as XmtpEnv,
   },
   {
     name: "agent3",
     walletKey: WALLET_KEY_AGENT3,
-    encryptionKey: ENCRYPTION_KEY_AGENT3,
+    encryptionKey: DB_ENCRYPTION_KEY_AGENT3,
     xmtpEnv: XMTP_ENV as XmtpEnv,
   },
 ];

--- a/examples/xmtp-multiple-workers/index.ts
+++ b/examples/xmtp-multiple-workers/index.ts
@@ -10,19 +10,19 @@ import {
 const {
   XMTP_ENV,
   WALLET_KEY_AGENT1,
-  ENCRYPTION_KEY_AGENT1,
+  DB_ENCRYPTION_KEY_AGENT1,
   WALLET_KEY_AGENT2,
-  ENCRYPTION_KEY_AGENT2,
+  DB_ENCRYPTION_KEY_AGENT2,
   WALLET_KEY_AGENT3,
-  ENCRYPTION_KEY_AGENT3,
+  DB_ENCRYPTION_KEY_AGENT3,
 } = validateEnvironment([
   "XMTP_ENV",
   "WALLET_KEY_AGENT1",
-  "ENCRYPTION_KEY_AGENT1",
+  "DB_ENCRYPTION_KEY_AGENT1",
   "WALLET_KEY_AGENT2",
-  "ENCRYPTION_KEY_AGENT2",
+  "DB_ENCRYPTION_KEY_AGENT2",
   "WALLET_KEY_AGENT3",
-  "ENCRYPTION_KEY_AGENT3",
+  "DB_ENCRYPTION_KEY_AGENT3",
 ]);
 
 /**
@@ -78,19 +78,19 @@ async function main(): Promise<void> {
     {
       name: "agent1",
       walletKey: WALLET_KEY_AGENT1,
-      encryptionKey: ENCRYPTION_KEY_AGENT1,
+      encryptionKey: DB_ENCRYPTION_KEY_AGENT1,
       xmtpEnv: XMTP_ENV as XmtpEnv,
     },
     {
       name: "agent2",
       walletKey: WALLET_KEY_AGENT2,
-      encryptionKey: ENCRYPTION_KEY_AGENT2,
+      encryptionKey: DB_ENCRYPTION_KEY_AGENT2,
       xmtpEnv: XMTP_ENV as XmtpEnv,
     },
     {
       name: "agent3",
       walletKey: WALLET_KEY_AGENT3,
-      encryptionKey: ENCRYPTION_KEY_AGENT3,
+      encryptionKey: DB_ENCRYPTION_KEY_AGENT3,
       xmtpEnv: XMTP_ENV as XmtpEnv,
     },
   ];

--- a/examples/xmtp-queue-dual-client/.env.example
+++ b/examples/xmtp-queue-dual-client/.env.example
@@ -1,5 +1,5 @@
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
+DB_ENCRYPTION_KEY= # a second random 32 bytes encryption key for local db encryption
 XMTP_ENV=dev # local, dev, production
 
 

--- a/examples/xmtp-queue-dual-client/README.md
+++ b/examples/xmtp-queue-dual-client/README.md
@@ -19,7 +19,7 @@ To run your XMTP agent, create a `.env` file with the following variables:
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/examples/xmtp-queue-dual-client/index.ts
+++ b/examples/xmtp-queue-dual-client/index.ts
@@ -7,10 +7,10 @@ import {
 } from "@helpers/client";
 import { Client, type LogLevel, type XmtpEnv } from "@xmtp/node-sdk";
 
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV, LOGGING_LEVEL } =
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV, LOGGING_LEVEL } =
   validateEnvironment([
     "WALLET_KEY",
-    "ENCRYPTION_KEY",
+    "DB_ENCRYPTION_KEY",
     "XMTP_ENV",
     "LOGGING_LEVEL",
   ]);
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
 
   // Create wallet signer and encryption key
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
   // Create receiving client
   const receivingClient = await Client.create(signer, {

--- a/examples/xmtp-smart-wallet/.env.example
+++ b/examples/xmtp-smart-wallet/.env.example
@@ -1,5 +1,5 @@
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 
 
 NETWORK_ID=base-sepolia # base-mainnet or others

--- a/examples/xmtp-smart-wallet/README.md
+++ b/examples/xmtp-smart-wallet/README.md
@@ -21,7 +21,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is
 
 NETWORK_ID=base-sepolia # base-mainnet or others

--- a/examples/xmtp-smart-wallet/index.ts
+++ b/examples/xmtp-smart-wallet/index.ts
@@ -15,13 +15,13 @@ const WALLET_PATH = "wallet.json";
  * that stores your agent's messages */
 const {
   XMTP_ENV,
-  ENCRYPTION_KEY,
+  DB_ENCRYPTION_KEY,
   NETWORK_ID,
   CDP_API_KEY_NAME,
   CDP_API_KEY_PRIVATE_KEY,
 } = validateEnvironment([
   "XMTP_ENV",
-  "ENCRYPTION_KEY",
+  "DB_ENCRYPTION_KEY",
   "NETWORK_ID",
   "CDP_API_KEY_NAME",
   "CDP_API_KEY_PRIVATE_KEY",
@@ -31,7 +31,7 @@ const main = async () => {
   const walletData = await initializeWallet(WALLET_PATH);
   /* Create the signer using viem and parse the encryption key for the local db */
   const signer = createSigner(walletData.seed);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
   const client = await Client.create(signer, {
     dbEncryptionKey,

--- a/examples/xmtp-thinking-reaction/README.md
+++ b/examples/xmtp-thinking-reaction/README.md
@@ -19,7 +19,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/examples/xmtp-thinking-reaction/index.ts
+++ b/examples/xmtp-thinking-reaction/index.ts
@@ -14,15 +14,15 @@ import { Client, type XmtpEnv } from "@xmtp/node-sdk";
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
  * that stores your agent's messages */
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
   "WALLET_KEY",
-  "ENCRYPTION_KEY",
+  "DB_ENCRYPTION_KEY",
   "XMTP_ENV",
 ]);
 
 /* Create the signer using viem and parse the encryption key for the local db */
 const signer = createSigner(WALLET_KEY);
-const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
 // Helper function to sleep for a specified number of milliseconds
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/examples/xmtp-transactions/.env.example
+++ b/examples/xmtp-transactions/.env.example
@@ -1,5 +1,5 @@
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is 0x..
 XMTP_ENV=dev # the environment to use for the xmtp client
 NETWORK_ID=base-sepolia # the network id to use for the xmtp client

--- a/examples/xmtp-transactions/README.md
+++ b/examples/xmtp-transactions/README.md
@@ -27,7 +27,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key for the wallet
-ENCRYPTION_KEY= # the encryption key for the wallet
+DB_ENCRYPTION_KEY= # the encryption key for the wallet
 # public key is
 
 NETWORK_ID=base-sepolia # base-mainnet or others

--- a/examples/xmtp-transactions/index.ts
+++ b/examples/xmtp-transactions/index.ts
@@ -15,10 +15,10 @@ import { USDCHandler } from "./usdc";
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
  * that stores your agent's messages */
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV, NETWORK_ID } =
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV, NETWORK_ID } =
   validateEnvironment([
     "WALLET_KEY",
-    "ENCRYPTION_KEY",
+    "DB_ENCRYPTION_KEY",
     "XMTP_ENV",
     "NETWORK_ID",
   ]);
@@ -27,7 +27,7 @@ async function main() {
   const usdcHandler = new USDCHandler(NETWORK_ID);
   /* Create the signer using viem and parse the encryption key for the local db */
   const signer = createSigner(WALLET_KEY);
-  const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+  const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
   /* Initialize the xmtp client */
   const client = await Client.create(signer, {
     dbEncryptionKey,

--- a/examples/xmtp-welcome-message/README.md
+++ b/examples/xmtp-welcome-message/README.md
@@ -109,7 +109,7 @@ To run your XMTP agent, you must create a `.env` file with the following variabl
 
 ```bash
 WALLET_KEY= # the private key of the wallet
-ENCRYPTION_KEY= # encryption key for the local database
+DB_ENCRYPTION_KEY= # encryption key for the local database
 XMTP_ENV=dev # local, dev, production
 ```
 

--- a/examples/xmtp-welcome-message/index.ts
+++ b/examples/xmtp-welcome-message/index.ts
@@ -22,15 +22,15 @@ import { IntentCodec, type IntentContent } from "./types/IntentContent";
 /* Get the wallet key associated to the public key of
  * the agent and the encryption key for the local db
  * that stores your agent's messages */
-const { WALLET_KEY, ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
+const { WALLET_KEY, DB_ENCRYPTION_KEY, XMTP_ENV } = validateEnvironment([
   "WALLET_KEY",
-  "ENCRYPTION_KEY",
+  "DB_ENCRYPTION_KEY",
   "XMTP_ENV",
 ]);
 
 /* Create the signer using viem and parse the encryption key for the local db */
 const signer = createSigner(WALLET_KEY);
-const dbEncryptionKey = getEncryptionKeyFromHex(ENCRYPTION_KEY);
+const dbEncryptionKey = getEncryptionKeyFromHex(DB_ENCRYPTION_KEY);
 
 /**
  * Send a welcome message with inline actions for ETH price

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -1,6 +1,5 @@
 import { getRandomValues } from "node:crypto";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { Client, IdentifierKind, type Signer } from "@xmtp/node-sdk";
 import { fromString, toString } from "uint8arrays";

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -88,18 +88,6 @@ export const logAgentDetails = async (client: Client): Promise<void> => {
   \x1b[0m`);
 
   const clientsByAddress = client.accountIdentifier?.identifier;
-  // Get XMTP SDK version from package.json
-  const require = createRequire(import.meta.url);
-  const packageJson = require("../package.json") as {
-    dependencies: Record<string, string>;
-  };
-  const xmtpSdkVersion = packageJson.dependencies["@xmtp/node-sdk"];
-  const bindingVersion = (
-    require("../node_modules/@xmtp/node-bindings/package.json") as {
-      version: string;
-    }
-  ).version;
-
   const inboxId = client.inboxId;
   const installationId = client.installationId;
   const environments = client.options?.env ?? "dev";
@@ -123,8 +111,6 @@ export const logAgentDetails = async (client: Client): Promise<void> => {
   console.log(`
     ✓ XMTP Client:
     • InboxId: ${inboxId}
-    • SDK: ${xmtpSdkVersion}
-    • Bindings: ${bindingVersion}
     • Version: ${Client.version}
     • Address: ${clientsByAddress}
     • Conversations: ${conversations.length}

--- a/scripts/generateKeys.ts
+++ b/scripts/generateKeys.ts
@@ -40,7 +40,7 @@ const xmtpEnvExists = existingEnv.includes("XMTP_ENV=");
 
 const envContent = `# keys for ${exampleName}
 WALLET_KEY=${walletKey}
-ENCRYPTION_KEY=${encryptionKeyHex}
+DB_ENCRYPTION_KEY=${encryptionKeyHex}
 ${!xmtpEnvExists ? "XMTP_ENV=dev\n" : ""}# public key is ${publicKey}
 `;
 

--- a/scripts/revokeInstallations.ts
+++ b/scripts/revokeInstallations.ts
@@ -92,7 +92,7 @@ async function main() {
   });
 
   // Validate required environment variables
-  const requiredVars = ["WALLET_KEY", "ENCRYPTION_KEY", "XMTP_ENV"];
+  const requiredVars = ["WALLET_KEY", "DB_ENCRYPTION_KEY", "XMTP_ENV"];
   const missingVars = requiredVars.filter((varName) => !envVars[varName]);
 
   if (missingVars.length > 0) {


### PR DESCRIPTION
### Rename environment variable ENCRYPTION_KEY to DB_ENCRYPTION_KEY throughout the repository for clarity and consistency across example apps, scripts, and documentation
This change updates the environment variable name used for database encryption from `ENCRYPTION_KEY` to `DB_ENCRYPTION_KEY` across code, scripts, and documentation and removes SDK/Bindings version logging from the agent details helper.

- Replace `ENCRYPTION_KEY` with `DB_ENCRYPTION_KEY` in example entrypoints, including `validateEnvironment`, `getEncryptionKeyFromHex`, and `initializeXmtpClient` usage (e.g., [examples/xmtp-gm/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9), [examples/xmtp-coinbase-agentkit/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-b7bfbea16a422f169ef1ed3b4d8a2ce445a4e156099da3c36089bf91b538e752), [examples/xmtp-queue-dual-client/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-12206c096c41164388d4ee5667242d27e93e10d89e76540088a30724f4138ced))
- Update example and root environment files and docs to reflect the new variable name (e.g., [.env.example](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c), [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [examples/xmtp-attachments/README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-8493426cf2865fd405869c5dd3a60b6c66f18b839b9bd135e22127bbca20c337))
- Modify scripts to generate and validate `DB_ENCRYPTION_KEY` (e.g., [scripts/generateKeys.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-cb5089ecceb276561844eb8c44432b03a43269e31c82a6bb97059cb4c3df9875), [scripts/revokeInstallations.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c))
- Remove SDK and Bindings version lines from agent details logging in [helpers/client.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1)
- Normalize YAML key formatting in [./cursor/rules/monorepo-guidelines.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-a32590ae7d1766c8a332777c4d9d2ab96a69f6a4b40af059fc23b876b6e4cfcc) and update related docs ([.cursor/rules/xmtp.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-aedc75362f13e18349d0c2674db6d7f886e2aa17c52ef0414cf942fc15526b20), [.cursor/rules/readme.mdc](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-c2d1b9fa7289c0ec375201c5c0bb674b29f4ee1870ffbeb5e4c961ba97017a8d))

#### 📍Where to Start
Start with `validateEnvironment` and key derivation in [examples/xmtp-gm/index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-188e41b80da48f67c994aab1958d77927d4d730c493cc7ed2554369f928c69d9), then review similar changes across other example entrypoints and the env generation in [scripts/generateKeys.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/249/files#diff-cb5089ecceb276561844eb8c44432b03a43269e31c82a6bb97059cb4c3df9875).

----

_[Macroscope](https://app.macroscope.com) summarized 9b7b256._