### PR TITLE
Refactor group creation code

### DIFF
--- a/examples/xmtp-gated-group/index.ts
+++ b/examples/xmtp-gated-group/index.ts
@@ -124,16 +124,12 @@ async function handleSuccessfulPassphrase(ctx: MessageContext) {
     // Check if we already have a group created
     // For simplicity, we'll create a new group each time
     // In a production app, you'd want to store the group ID
-    const group = await agent.createGroupWithAddresses(
-      [(await ctx.getSenderAddress()) as `0x${string}`],
-      {
-        groupName: GROUP_CONFIG.groupName,
-        groupDescription: GROUP_CONFIG.groupDescription,
-      },
-    );
+    const group = await agent.createGroupWithAddresses([], {
+      groupName: GROUP_CONFIG.groupName,
+      groupDescription: GROUP_CONFIG.groupDescription,
+    });
 
     // Add the user to the groupn
-
     await group.addMembers([(await ctx.getSenderAddress()) as `0x${string}`]);
 
     // Send success messages


### PR DESCRIPTION
### Refactor group creation in `examples/xmtp-gated-group/index.ts` to create groups with zero initial members and add the sender only via `group.addMembers` for group creation code
Update `handleSuccessfulPassphrase` to instantiate the group with an empty member list and rely on a subsequent `group.addMembers(...)` call to add the sender. Minor formatting and comment adjustments are included in the same file. See [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/280/files#diff-0e115e5d17f45288a804052c8181cde8942cb25a0cbe80cfd416de55bca4765a).

#### 📍Where to Start
Start at the `handleSuccessfulPassphrase` handler in [index.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/280/files#diff-0e115e5d17f45288a804052c8181cde8942cb25a0cbe80cfd416de55bca4765a).

----

_[Macroscope](https://app.macroscope.com) summarized 033aa62._