### PR TITLE
Remove outdated SDK info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> 🚀 **Now with the latest XMTP Agent SDK!** These examples have been updated to use the newest version of the [`agent-sdk`](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk). Want to go back to legacy? try out the [node-sdk branch](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/node-sdk).
-
 # XMTP agent examples
 
 These example agents serve as a starting point for building your own agents. They are built with the [`agent-sdk`](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk) and run on the [XMTP](https://docs.xmtp.org/) network.


### PR DESCRIPTION
### Remove outdated XMTP Agent SDK announcement and legacy node-sdk link from [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/282/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
This change deletes the introductory line in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/282/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) that references the latest XMTP Agent SDK and removes the link to the legacy `node-sdk` branch at the top of the file.

#### 📍Where to Start
Start by reviewing the diff in [README.md](https://github.com/ephemeraHQ/xmtp-agent-examples/pull/282/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), focusing on the removed introductory announcement and legacy branch link at the top of the file.

----

_[Macroscope](https://app.macroscope.com) summarized 740cdf1._